### PR TITLE
ci: add scheduled mutation workflow

### DIFF
--- a/.github/workflows/schedule.yaml
+++ b/.github/workflows/schedule.yaml
@@ -1,0 +1,32 @@
+name: Scheduled CI
+
+on:
+  schedule:
+    - cron: '17 10 1/3 * *'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        node-version: [12.x, 14.x, 16.x]
+
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          ref: develop
+
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v1
+        with:
+          node-version: ${{ matrix.node-version }}
+
+      - name: Npm Install
+        run: npm install
+
+      - name: Build
+        run: npm run build
+
+      - name: Mutations
+        run: npm run mutations


### PR DESCRIPTION
### :clap: Resolves

N/A
     
### :star2: Description

Adds a workflow to run mutation tests every 3 days at 0600 EST.

This already exists on develop, but I think it needs to exist on main to actually run.