### PR TITLE
feat: add support for finding the nearest common ancestor of explicit types

### DIFF
--- a/src/exceptions.ts
+++ b/src/exceptions.ts
@@ -12,3 +12,9 @@ export class IncompatibleType extends Error {
         `The type instance ${t} is incompatible with the given TypeHierarchy`);
   }
 }
+
+export class NotFinalized extends Error {
+  constructor() {
+    super('The TypeHierarchy has not been finalized');
+  }
+}

--- a/src/type_definition.ts
+++ b/src/type_definition.ts
@@ -92,7 +92,7 @@ export class TypeDefinition {
         p => this.hierarchy.getTypeDef(p.name).addDescendant(t));
   }
 
-  private createInstance(): TypeInstantiation {
+  createInstance(): TypeInstantiation {
     return new TypeInstantiation(this.name);
   }
 }

--- a/src/type_hierarchy.ts
+++ b/src/type_hierarchy.ts
@@ -6,9 +6,101 @@
 
 import {TypeDefinition} from './type_definition';
 import {TypeInstantiation} from './type_instantiation';
+import {removeDuplicates} from './utils';
+import {NotFinalized} from './exceptions';
 
 export class TypeHierarchy {
-  private typeDefsMap = new Map();
+  /**
+   * A map of type names to TypeDefinitions.
+   */
+  private readonly typeDefsMap: Map<string, TypeDefinition> = new Map();
+
+  /**
+   * A map of type names to maps of type names to lists of type names that are
+   * the nearest common ancestors of the two types. You can think of this like
+   * a two-dimensional array where both axes contain all of the type names.
+   *
+   * A nearest common ancestor of two types x and y is defined as:
+   * An ancestor type of both x and y that has no descendant which  is also an
+   * ancestor of both x and y.
+   */
+  private readonly nearestCommonAncestors:
+      Map<string, Map<string, TypeInstantiation[]>> = new Map();
+
+  /**
+   * Whether this type hierarchy has had finalize() called on it or not.
+   */
+  private finalized = false;
+
+  /**
+   * Handles any processing that needs to be done on the type hierarchy
+   * post-configuration. Eg figuring out the nearest common ancestors of every
+   * pair of types.
+   */
+  finalize() {
+    this.initNearestCommonAncestors();
+    this.finalized = true;
+  }
+
+  /**
+   * Initializes the nearestCommonAncestors graph so the nearest common
+   * ancestors of two types can be accessed inconstant time.
+   *
+   * Implements the pre-processing algorithm defined in:
+   * Czumaj, Artur, Miroslaw Kowaluk and and Andrzej Lingas. "Faster algorithms
+   * for finding lowest common ancestors in directed acyclic graphs."
+   * Theoretical Computer Science, 380.1-2 (2007): 37-46.
+   * https://bit.ly/2SrCRs5
+   *
+   * Operates in O(nm) where n is the number of nodes and m is the number of
+   * edges.
+   */
+  private initNearestCommonAncestors() {
+    const unvisited = new Map(this.typeDefsMap);
+    while (unvisited.size) {
+      unvisited.forEach((t: TypeDefinition) => {
+        if (t.parents.some(p => unvisited.has(p.name))) return;
+        unvisited.delete(t.name);
+        this.nearestCommonAncestors.set(
+            t.name, this.createNearestCommonAncestorMap(t));
+      })
+    }
+  }
+
+  /**
+   * Creates a map of type names to arrays of TypeInstantiations which are the
+   * nearest common ancestors of the type key and the type passed to this
+   * method.
+   */
+  private createNearestCommonAncestorMap(
+      t1: TypeDefinition
+  ): Map<string, TypeInstantiation[]> {
+    const map = new Map();
+    this.typeDefsMap.forEach((t2: TypeDefinition) => {
+      const t2i = t2.createInstance();
+      if (t1.hasDescendant(t2i)) {
+        map.set(t2.name, [t1.createInstance()]);
+      } else {
+        map.set(
+            t2.name,
+            t1.parents
+                .flatMap(pi => this.getNearestCommonAncestorsOfPair(pi, t2i))
+                .filter(removeDuplicates())
+                .filter(this.removeDescendants()));
+      }
+    });
+    return map;
+  }
+
+  /**
+   * This generates a callback which is meant to be passed to Array.filter().
+   * Removes any TypeInstantiations that also have descendants in the array.
+   */
+  private removeDescendants() {
+    return (t1, i, arr) =>
+        arr.every(
+            (t2, j) => i == j || !this.getTypeDef(t1.name).hasDescendant(t2));
+  }
 
   /**
    * Adds a new type definition with the given name to this type hierarchy, and
@@ -43,5 +135,23 @@ export class TypeHierarchy {
    */
   typeFulfillsType(a: TypeInstantiation, b: TypeInstantiation): boolean {
     return this.typeDefsMap.get(a.name).hasAncestor(b);
+  }
+
+  getNearestCommonAncestors(
+      ...types: TypeInstantiation[]
+  ): TypeInstantiation[] {
+    if (!this.finalized) throw new NotFinalized();
+    if (types.length < 2) return types;
+
+    return types.reduce(
+        (ncas, type) =>
+          ncas.flatMap(nca => this.getNearestCommonAncestorsOfPair(type, nca))
+              .filter(removeDuplicates()),
+        [types[0]]);
+  }
+
+  private getNearestCommonAncestorsOfPair(
+      a: TypeInstantiation, b: TypeInstantiation) {
+    return this.nearestCommonAncestors.get(a.name).get(b.name);
   }
 }

--- a/src/type_hierarchy.ts
+++ b/src/type_hierarchy.ts
@@ -63,7 +63,7 @@ export class TypeHierarchy {
         unvisited.delete(t.name);
         this.nearestCommonAncestors.set(
             t.name, this.createNearestCommonAncestorMap(t));
-      })
+      });
     }
   }
 
@@ -98,8 +98,8 @@ export class TypeHierarchy {
    */
   private removeDescendants() {
     return (t1, i, arr) =>
-        arr.every(
-            (t2, j) => i == j || !this.getTypeDef(t1.name).hasDescendant(t2));
+      arr.every(
+          (t2, j) => i == j || !this.getTypeDef(t1.name).hasDescendant(t2));
   }
 
   /**
@@ -137,6 +137,9 @@ export class TypeHierarchy {
     return this.typeDefsMap.get(a.name).hasAncestor(b);
   }
 
+  /**
+   * Returns the nearest common ancestor(s) of the given types.
+   */
   getNearestCommonAncestors(
       ...types: TypeInstantiation[]
   ): TypeInstantiation[] {
@@ -150,6 +153,10 @@ export class TypeHierarchy {
         [types[0]]);
   }
 
+  /**
+   * Returns the nearest common ancestor(s) of the given type pair, as defined
+   * in the nearestCommonAncestors array.
+   */
   private getNearestCommonAncestorsOfPair(
       a: TypeInstantiation, b: TypeInstantiation) {
     return this.nearestCommonAncestors.get(a.name).get(b.name);

--- a/src/type_hierarchy.ts
+++ b/src/type_hierarchy.ts
@@ -16,12 +16,13 @@ export class TypeHierarchy {
   private readonly typeDefsMap: Map<string, TypeDefinition> = new Map();
 
   /**
-   * A map of type names to maps of type names to lists of type names that are
-   * the nearest common ancestors of the two types. You can think of this like
-   * a two-dimensional array where both axes contain all of the type names.
+   * A map of type names to maps of type names to lists of TypeInstantiations
+   * that are the nearest common ancestors of the two types. You can think of
+   * this like a two-dimensional array where both axes contain all of the type
+   * names.
    *
    * A nearest common ancestor of two types x and y is defined as:
-   * An ancestor type of both x and y that has no descendant which  is also an
+   * An ancestor type of both x and y that has no descendant which is also an
    * ancestor of both x and y.
    */
   private readonly nearestCommonAncestors:
@@ -44,7 +45,7 @@ export class TypeHierarchy {
 
   /**
    * Initializes the nearestCommonAncestors graph so the nearest common
-   * ancestors of two types can be accessed inconstant time.
+   * ancestors of two types can be accessed in inconstant time.
    *
    * Implements the pre-processing algorithm defined in:
    * Czumaj, Artur, Miroslaw Kowaluk and and Andrzej Lingas. "Faster algorithms
@@ -69,8 +70,8 @@ export class TypeHierarchy {
 
   /**
    * Creates a map of type names to arrays of TypeInstantiations which are the
-   * nearest common ancestors of the type key and the type passed to this
-   * method.
+   * nearest common ancestors of the type represented by the name and the type
+   * passed to this method.
    */
   private createNearestCommonAncestorMap(
       t1: TypeDefinition
@@ -93,8 +94,8 @@ export class TypeHierarchy {
   }
 
   /**
-   * This generates a callback which is meant to be passed to Array.filter().
-   * Removes any TypeInstantiations that also have descendants in the array.
+   * Returns a filter function which removes any TypeInstantiations that also
+   * have descendants in the array.
    */
   private removeDescendants() {
     return (t1, i, arr) =>

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,0 +1,18 @@
+/**
+ * @license
+ * Copyright 2021 Beka Westberg
+ * SPDX-License-Identifier: MIT
+ */
+
+/**
+ * Returns a filter function which removes all the duplicates from an array in
+ * O(n). Note that this only looks for shallow equality, not deep equality.
+ */
+export function removeDuplicates(): (el: unknown) => boolean {
+  const hash = new Set();
+  return (el) => {
+    if (hash.has(el)) return false;
+    hash.add(el);
+    return true;
+  }
+}

--- a/test/nearest_common_ancestors.mocha.js
+++ b/test/nearest_common_ancestors.mocha.js
@@ -25,8 +25,15 @@ suite('Nearest common ancestors', function() {
       chai.assert.isTrue(aas.every((aa, i) => aa.equals(eas[i])), msg)
     }
 
+    test('not being finalized throws errors', function() {
+      const h = new TypeHierarchy();
+
+      assert.throws(h.nearestCommonAncestors());
+    });
+
     test('nca of no types is null', function() {
       const h = new TypeHierarchy();
+      h.finalize();
 
       assert.isNull(
           h.nearestCommonAncestors(),
@@ -36,6 +43,7 @@ suite('Nearest common ancestors', function() {
     test('nca of one type is itself', function() {
       const h = new TypeHierarchy();
       h.addTypeDef('t');
+      h.finalize();
       const ti = new TypeInstantiation('t')
 
       assertNearestCommonAncestors(
@@ -48,6 +56,7 @@ suite('Nearest common ancestors', function() {
       h.addTypeDef('b');
       const ai = new TypeInstantiation('a')
       const bi = new TypeInstantiation('b')
+      h.finalize();
 
       assert.isNull(
           h.nearestCommonAncestors(ai, bi),
@@ -59,6 +68,7 @@ suite('Nearest common ancestors', function() {
       h.addTypeDef('t');
       const ti1 = new TypeInstantiation('t')
       const ti2 = new TypeInstantiation('t')
+      h.finalize();
 
       assertNearestCommonAncestors(
           h, [ti1, ti2], [ti1],
@@ -72,6 +82,7 @@ suite('Nearest common ancestors', function() {
       const ti = new TypeInstantiation('t')
       const pi = new TypeInstantiation('p');
       td.addParent(pi);
+      h.finalize();
 
       assertNearestCommonAncestors(
           h, [ti, pi], [pi],
@@ -88,6 +99,7 @@ suite('Nearest common ancestors', function() {
       const gpi = new TypeInstantiation('gp');
       pd.addParent(gpi);
       td.addParent(pi);
+      h.finalize();
 
       assertNearestCommonAncestors(
           h, [ti, gpi], [gpi],
@@ -105,6 +117,7 @@ suite('Nearest common ancestors', function() {
           const gpi = new TypeInstantiation('gp');
           pd.addParent(gpi);
           td.addParent(pi);
+          h.finalize();
 
           assertNearestCommonAncestors(
               h, [ti, pi, gpi], [gpi],
@@ -121,6 +134,7 @@ suite('Nearest common ancestors', function() {
       const pi = new TypeInstantiation('p')
       ad.addParent(pi);
       bd.addParent(pi);
+      h.finalize();
 
       assertNearestCommonAncestors(
           h, [ai, bi], [pi],
@@ -139,6 +153,7 @@ suite('Nearest common ancestors', function() {
       const pi = new TypeInstantiation('p')
       ad.addParent(pi);
       bd.addParent(pi);
+      h.finalize();
 
       assertNearestCommonAncestors(
           h, [ci, bi, ai], [pi],
@@ -161,6 +176,7 @@ suite('Nearest common ancestors', function() {
       pbd.addParent(gpi);
       cad.addParent(pai);
       cbd.addParent(pbi);
+      h.fianlize();
 
       assertNearestCommonAncestors(
           h, [cai, cbi], [gpi],
@@ -180,6 +196,7 @@ suite('Nearest common ancestors', function() {
       pad.addParent(gpi);
       pbd.addParent(gpi);
       cd.addParent(pai);
+      h.finalize();
 
       assertNearestCommonAncestors(
           h, [ci, pbi], [gpi],
@@ -201,6 +218,7 @@ suite('Nearest common ancestors', function() {
           cad.addParent(pbi);
           cbd.addParent(pai);
           cbd.addParent(pbi);
+          h.finalize();
 
           assertNearestCommonAncestors(
               h, [cai, cbi], [pai, pbi],
@@ -228,6 +246,7 @@ suite('Nearest common ancestors', function() {
           cbd.addParent(pbi);
           cbd.addParent(pci);
           cbd.addParent(pdi);
+          h.finalize();
 
           assertNearestCommonAncestors(
               h, [cai, cbi], [pbi, pci],
@@ -274,6 +293,8 @@ suite('Nearest common ancestors', function() {
         yd.addParent(vi);
         yd.addParent(zi);
         xd.addParent(zi);
+
+        h.finalize();
 
         return h;
       }

--- a/test/nearest_common_ancestors.mocha.js
+++ b/test/nearest_common_ancestors.mocha.js
@@ -10,7 +10,6 @@ import {assert} from 'chai';
 import {NotFinalized} from '../src/exceptions';
 
 suite('Nearest common ancestors', function() {
-  // TODO: Test for three siblings.
   suite('basic explicit nearest common ancestors', function() {
     /**
      * Asserts that the nearest common ancestors of the types ts are the
@@ -25,7 +24,7 @@ suite('Nearest common ancestors', function() {
     function assertNearestCommonAncestors(h, ts, eas, msg) {
       const aas = h.getNearestCommonAncestors(...ts);
       assert.equal(aas.length, eas.length, msg);
-      assert.isTrue(aas.every((aa, i) => aa.equals(eas[i])), msg)
+      assert.isTrue(aas.every((aa, i) => aa.equals(eas[i])), msg);
     }
 
     test('not being finalized throws errors', function() {
@@ -50,7 +49,7 @@ suite('Nearest common ancestors', function() {
       const h = new TypeHierarchy();
       h.addTypeDef('t');
       h.finalize();
-      const ti = new TypeInstantiation('t')
+      const ti = new TypeInstantiation('t');
 
       assertNearestCommonAncestors(
           h, [ti], [ti], 'Expected the nca of one type to be itself');
@@ -60,8 +59,8 @@ suite('Nearest common ancestors', function() {
       const h = new TypeHierarchy();
       h.addTypeDef('a');
       h.addTypeDef('b');
-      const ai = new TypeInstantiation('a')
-      const bi = new TypeInstantiation('b')
+      const ai = new TypeInstantiation('a');
+      const bi = new TypeInstantiation('b');
       h.finalize();
 
       assert.isEmpty(
@@ -72,8 +71,8 @@ suite('Nearest common ancestors', function() {
     test('nca of a type and itself is itself', function() {
       const h = new TypeHierarchy();
       h.addTypeDef('t');
-      const ti1 = new TypeInstantiation('t')
-      const ti2 = new TypeInstantiation('t')
+      const ti1 = new TypeInstantiation('t');
+      const ti2 = new TypeInstantiation('t');
       h.finalize();
 
       assertNearestCommonAncestors(
@@ -84,8 +83,8 @@ suite('Nearest common ancestors', function() {
     test('nca of a type and its parent is the parent', function() {
       const h = new TypeHierarchy();
       const td = h.addTypeDef('t');
-      h.addTypeDef('p')
-      const ti = new TypeInstantiation('t')
+      h.addTypeDef('p');
+      const ti = new TypeInstantiation('t');
       const pi = new TypeInstantiation('p');
       td.addParent(pi);
       h.finalize();
@@ -98,9 +97,9 @@ suite('Nearest common ancestors', function() {
     test('nca of a type and its grandparent is the grandparent', function() {
       const h = new TypeHierarchy();
       const td = h.addTypeDef('t');
-      const pd = h.addTypeDef('p')
-      h.addTypeDef('gp')
-      const ti = new TypeInstantiation('t')
+      const pd = h.addTypeDef('p');
+      h.addTypeDef('gp');
+      const ti = new TypeInstantiation('t');
       const pi = new TypeInstantiation('p');
       const gpi = new TypeInstantiation('gp');
       pd.addParent(gpi);
@@ -116,9 +115,9 @@ suite('Nearest common ancestors', function() {
         function() {
           const h = new TypeHierarchy();
           const td = h.addTypeDef('t');
-          const pd = h.addTypeDef('p')
-          h.addTypeDef('gp')
-          const ti = new TypeInstantiation('t')
+          const pd = h.addTypeDef('p');
+          h.addTypeDef('gp');
+          const ti = new TypeInstantiation('t');
           const pi = new TypeInstantiation('p');
           const gpi = new TypeInstantiation('gp');
           pd.addParent(gpi);
@@ -128,16 +127,16 @@ suite('Nearest common ancestors', function() {
           assertNearestCommonAncestors(
               h, [ti, pi, gpi], [gpi],
               'Expected the nca of a type and its grandparent to be the grandparent');
-        })
+        });
 
     test('nca of two siblings is their parent', function() {
       const h = new TypeHierarchy();
       const ad = h.addTypeDef('a');
       const bd = h.addTypeDef('b');
       h.addTypeDef('p');
-      const ai = new TypeInstantiation('a')
-      const bi = new TypeInstantiation('b')
-      const pi = new TypeInstantiation('p')
+      const ai = new TypeInstantiation('a');
+      const bi = new TypeInstantiation('b');
+      const pi = new TypeInstantiation('p');
       ad.addParent(pi);
       bd.addParent(pi);
       h.finalize();
@@ -153,10 +152,10 @@ suite('Nearest common ancestors', function() {
       const bd = h.addTypeDef('b');
       const cd = h.addTypeDef('c');
       h.addTypeDef('p');
-      const ai = new TypeInstantiation('a')
-      const bi = new TypeInstantiation('b')
-      const ci = new TypeInstantiation('c')
-      const pi = new TypeInstantiation('p')
+      const ai = new TypeInstantiation('a');
+      const bi = new TypeInstantiation('b');
+      const ci = new TypeInstantiation('c');
+      const pi = new TypeInstantiation('p');
       ad.addParent(pi);
       bd.addParent(pi);
       cd.addParent(pi);
@@ -260,6 +259,41 @@ suite('Nearest common ancestors', function() {
               'Expected the ncas two siblings with some shared parents to be the shared parents');
         });
 
+    test('ncas of three siblings with some shared parents is the shared parent',
+        function() {
+          const h = new TypeHierarchy();
+          h.addTypeDef('pa');
+          h.addTypeDef('pb');
+          h.addTypeDef('pc');
+          h.addTypeDef('pd');
+          h.addTypeDef('pe');
+          const cad = h.addTypeDef('ca');
+          const cbd = h.addTypeDef('cb');
+          const ccd = h.addTypeDef('cc');
+          const pai = new TypeInstantiation('pa');
+          const pbi = new TypeInstantiation('pb');
+          const pci = new TypeInstantiation('pc');
+          const pdi = new TypeInstantiation('pd');
+          const pei = new TypeInstantiation('pe');
+          const cai = new TypeInstantiation('ca');
+          const cbi = new TypeInstantiation('cb');
+          const cci = new TypeInstantiation('cc');
+          cad.addParent(pai);
+          cad.addParent(pbi);
+          cad.addParent(pci);
+          cbd.addParent(pbi);
+          cbd.addParent(pci);
+          cbd.addParent(pdi);
+          ccd.addParent(pci);
+          ccd.addParent(pdi);
+          ccd.addParent(pei);
+          h.finalize();
+
+          assertNearestCommonAncestors(
+              h, [cai, cbi, cci], [pci],
+              'Expected the ncas three siblings with some shared parents to be the share parent');
+        });
+
     /* All of these tests  use the follow graph. Children are below their
      * ancestors.
      *
@@ -314,7 +348,7 @@ suite('Nearest common ancestors', function() {
         const ui = new TypeInstantiation('u');
         assertNearestCommonAncestors(
             h, [xi, yi], [ui, zi],
-            'Expected the ncas of X and Y to be Z and U')
+            'Expected the ncas of X and Y to be Z and U');
       });
 
       test('nca of X, Y, and Z is Z', function() {
@@ -324,7 +358,7 @@ suite('Nearest common ancestors', function() {
         const zi = new TypeInstantiation('z');
         assertNearestCommonAncestors(
             h, [xi, yi, zi], [zi],
-            'Expected the nca of X, Y and Z to be Z')
+            'Expected the nca of X, Y and Z to be Z');
       });
 
       test('nca of X, Y, and W is W', function() {
@@ -334,7 +368,7 @@ suite('Nearest common ancestors', function() {
         const wi = new TypeInstantiation('w');
         assertNearestCommonAncestors(
             h, [xi, yi, wi], [wi],
-            'Expected the nca of X, Y and W to be W')
+            'Expected the nca of X, Y and W to be W');
       });
 
       test('ncas of X, Y, and V are W and U', function() {
@@ -346,10 +380,10 @@ suite('Nearest common ancestors', function() {
         const ui = new TypeInstantiation('u');
         assertNearestCommonAncestors(
             h, [xi, yi, vi], [ui, wi],
-            'Expected the ncas of X, Y and V to be W and U')
+            'Expected the ncas of X, Y and V to be W and U');
       });
 
-      test('nca of X, Y, and Q is U', function () {
+      test('nca of X, Y, and Q is U', function() {
         const h = createHierarchy();
         const xi = new TypeInstantiation('x');
         const yi = new TypeInstantiation('y');
@@ -357,7 +391,7 @@ suite('Nearest common ancestors', function() {
         const ui = new TypeInstantiation('u');
         assertNearestCommonAncestors(
             h, [xi, yi, qi], [ui],
-            'Expected the nca of X, Y and Q to be U')
+            'Expected the nca of X, Y and Q to be U');
       });
     });
   });

--- a/test/nearest_common_ancestors.mocha.js
+++ b/test/nearest_common_ancestors.mocha.js
@@ -1,0 +1,336 @@
+/**
+ * @license
+ * Copyright 2021 Beka Westberg
+ * SPDX-License-Identifier: MIT
+ */
+
+import {TypeHierarchy} from '../src/type_hierarchy';
+import {TypeInstantiation} from '../src/type_instantiation';
+import {assert} from 'chai';
+
+suite('Nearest common ancestors', function() {
+  suite('basic explicit nearest common ancestors', function() {
+    /**
+     * Asserts that the nearest common ancestors of the types ts are the
+     * ancestors as.
+     * @param {!TypeHierarchy} h The hierarchy to use to find the nearest common
+     *     ancestors.
+     * @param {!Array<TypeInstantiation>} ts The types to find the nearest
+     *     common ancestors of.
+     * @param {!Array<!TypeInstantiation>} eas The expected ancestors.
+     * @param {string} msg The message to include in the assertion.
+     */
+    function assertNearestCommonAncestors(h, ts, eas, msg) {
+      const aas = h.getNearestCommonAncestors(ts);
+      chai.assert.isTrue(aas.every((aa, i) => aa.equals(eas[i])), msg)
+    }
+
+    test('nca of no types is null', function() {
+      const h = new TypeHierarchy();
+
+      assert.isNull(
+          h.nearestCommonAncestors(),
+          'Expected the nca of no types to be null');
+    });
+
+    test('nca of one type is itself', function() {
+      const h = new TypeHierarchy();
+      h.addTypeDef('t');
+      const ti = new TypeInstantiation('t')
+
+      assertNearestCommonAncestors(
+          h, [ti], [ti], 'Expected the nca of one type to be itself');
+    });
+
+    test('nca of two unrelated types is null', function() {
+      const h = new TypeHierarchy();
+      h.addTypeDef('a');
+      h.addTypeDef('b');
+      const ai = new TypeInstantiation('a')
+      const bi = new TypeInstantiation('b')
+
+      assert.isNull(
+          h.nearestCommonAncestors(ai, bi),
+          'Expected the nca of two unrelated types to be null');
+    });
+
+    test('nca of a type and itself is itself', function() {
+      const h = new TypeHierarchy();
+      h.addTypeDef('t');
+      const ti1 = new TypeInstantiation('t')
+      const ti2 = new TypeInstantiation('t')
+
+      assertNearestCommonAncestors(
+          h, [ti1, ti2], [ti1],
+          'Expected the nca of a type and itself to be itself');
+    });
+
+    test('nca of a type and its parent is the parent', function() {
+      const h = new TypeHierarchy();
+      const td = h.addTypeDef('t');
+      h.addTypeDef('p')
+      const ti = new TypeInstantiation('t')
+      const pi = new TypeInstantiation('p');
+      td.addParent(pi);
+
+      assertNearestCommonAncestors(
+          h, [ti, pi], [pi],
+          'Expected the nca of a type and its parent to be the parent');
+    });
+
+    test('nca of a type and its grandparent is the grandparent', function() {
+      const h = new TypeHierarchy();
+      const td = h.addTypeDef('t');
+      const pd = h.addTypeDef('p')
+      h.addTypeDef('gp')
+      const ti = new TypeInstantiation('t')
+      const pi = new TypeInstantiation('p');
+      const gpi = new TypeInstantiation('gp');
+      pd.addParent(gpi);
+      td.addParent(pi);
+
+      assertNearestCommonAncestors(
+          h, [ti, gpi], [gpi],
+          'Expected the nca of a type and its grandparent to be the grandparent');
+    });
+
+    test('nca of a type, its parent, and its grandparent is the grandparent',
+        function() {
+          const h = new TypeHierarchy();
+          const td = h.addTypeDef('t');
+          const pd = h.addTypeDef('p')
+          h.addTypeDef('gp')
+          const ti = new TypeInstantiation('t')
+          const pi = new TypeInstantiation('p');
+          const gpi = new TypeInstantiation('gp');
+          pd.addParent(gpi);
+          td.addParent(pi);
+
+          assertNearestCommonAncestors(
+              h, [ti, pi, gpi], [gpi],
+              'Expected the nca of a type and its grandparent to be the grandparent');
+        })
+
+    test('nca of two siblings is their parent', function() {
+      const h = new TypeHierarchy();
+      const ad = h.addTypeDef('a');
+      const bd = h.addTypeDef('b');
+      h.addTypeDef('p');
+      const ai = new TypeInstantiation('a')
+      const bi = new TypeInstantiation('b')
+      const pi = new TypeInstantiation('p')
+      ad.addParent(pi);
+      bd.addParent(pi);
+
+      assertNearestCommonAncestors(
+          h, [ai, bi], [pi],
+          'Expected the nca of two siblings to be their parent');
+    });
+
+    test('nca of three siblings is their parent', function() {
+      const h = new TypeHierarchy();
+      const ad = h.addTypeDef('a');
+      const bd = h.addTypeDef('b');
+      const cd = h.addTypeDef('c');
+      h.addTypeDef('p');
+      const ai = new TypeInstantiation('a')
+      const bi = new TypeInstantiation('b')
+      const ci = new TypeInstantiation('c')
+      const pi = new TypeInstantiation('p')
+      ad.addParent(pi);
+      bd.addParent(pi);
+
+      assertNearestCommonAncestors(
+          h, [ci, bi, ai], [pi],
+          'Expected the nca of three siblings to be their parent');
+    });
+
+    test('nca of two cousins is the grandparent', function() {
+      const h = new TypeHierarchy();
+      h.addTypeDef('gp');
+      const pad = h.addTypeDef('pa');
+      const pbd = h.addTypeDef('pb');
+      const cad = h.addTypeDef('ca');
+      const cbd = h.addTypeDef('cb');
+      const gpi = new TypeInstantiation('gp');
+      const pai = new TypeInstantiation('pa');
+      const pbi = new TypeInstantiation('pb');
+      const cai = new TypeInstantiation('ca');
+      const cbi = new TypeInstantiation('cb');
+      pad.addParent(gpi);
+      pbd.addParent(gpi);
+      cad.addParent(pai);
+      cbd.addParent(pbi);
+
+      assertNearestCommonAncestors(
+          h, [cai, cbi], [gpi],
+          'Expected the nca of two cousins to be the grandparent');
+    });
+
+    test('nca of a type and its parsib is the grandparent', function() {
+      const h = new TypeHierarchy();
+      h.addTypeDef('gp');
+      const pad = h.addTypeDef('pa');
+      const pbd = h.addTypeDef('pb');
+      const cd = h.addTypeDef('c');
+      const gpi = new TypeInstantiation('gp');
+      const pai = new TypeInstantiation('pa');
+      const pbi = new TypeInstantiation('pb');
+      const ci = new TypeInstantiation('c');
+      pad.addParent(gpi);
+      pbd.addParent(gpi);
+      cd.addParent(pai);
+
+      assertNearestCommonAncestors(
+          h, [ci, pbi], [gpi],
+          'Expected the nca of a type and its parsib to be its grandparent');
+    });
+
+    test('ncas of two siblings with multiple shared parents are the parents',
+        function() {
+          const h = new TypeHierarchy();
+          h.addTypeDef('pa');
+          h.addTypeDef('pb');
+          const cad = h.addTypeDef('ca');
+          const cbd = h.addTypeDef('cb');
+          const pai = new TypeInstantiation('pa');
+          const pbi = new TypeInstantiation('pb');
+          const cai = new TypeInstantiation('ca');
+          const cbi = new TypeInstantiation('cb');
+          cad.addParent(pai);
+          cad.addParent(pbi);
+          cbd.addParent(pai);
+          cbd.addParent(pbi);
+
+          assertNearestCommonAncestors(
+              h, [cai, cbi], [pai, pbi],
+              'Expected the ncas two siblings with multiple shared parents to be the parents');
+        });
+
+    test('ncas of two siblings with some shared parents are the shared parents',
+        function() {
+          const h = new TypeHierarchy();
+          h.addTypeDef('pa');
+          h.addTypeDef('pb');
+          h.addTypeDef('pc');
+          h.addTypeDef('pd');
+          const cad = h.addTypeDef('ca');
+          const cbd = h.addTypeDef('cb');
+          const pai = new TypeInstantiation('pa');
+          const pbi = new TypeInstantiation('pb');
+          const pci = new TypeInstantiation('pc');
+          const pdi = new TypeInstantiation('pd');
+          const cai = new TypeInstantiation('ca');
+          const cbi = new TypeInstantiation('cb');
+          cad.addParent(pai);
+          cad.addParent(pbi);
+          cad.addParent(pci);
+          cbd.addParent(pbi);
+          cbd.addParent(pci);
+          cbd.addParent(pdi);
+
+          assertNearestCommonAncestors(
+              h, [cai, cbi], [pbi, pci],
+              'Expected the ncas two siblings with some shared parents to be the shared parents');
+        });
+
+    /* All of these tests  use the follow graph. Children are below their
+     * ancestors.
+     *
+     *        u ----.
+     *      /   \    \
+     *    /      \    \
+     *  /     W   |    \
+     * |    / | \ |     Q
+     * |  /   |   V     |
+     * | |    Z    \    |
+     * | |  /   \  |   /
+     * \ | /     \ | /
+     *   X         Y
+     */
+    suite('complex graph unions', function() {
+      function createHierarchy() {
+        const h = new TypeHierarchy();
+        const qd = h.addTypeDef('q');
+        h.addTypeDef('u');
+        const vd = h.addTypeDef('v');
+        h.addTypeDef('w');
+        const xd = h.addTypeDef('x');
+        const yd = h.addTypeDef('y');
+        const zd = h.addTypeDef('z');
+        const qi = new TypeInstantiation('q');
+        const ui = new TypeInstantiation('u');
+        const vi = new TypeInstantiation('v');
+        const wi = new TypeInstantiation('w');
+        const zi = new TypeInstantiation('z');
+
+        qd.addParent(ui);
+        vd.addParent(ui);
+        xd.addParent(ui);
+        vd.addParent(wi);
+        zd.addParent(wi);
+        xd.addParent(wi);
+        yd.addParent(qi);
+        yd.addParent(vi);
+        yd.addParent(zi);
+        xd.addParent(zi);
+
+        return h;
+      }
+
+      test('ncas of X and Y are Z and U', function() {
+        const h = createHierarchy();
+        const xi = new TypeInstantiation('x');
+        const yi = new TypeInstantiation('y');
+        const zi = new TypeInstantiation('z');
+        const ui = new TypeInstantiation('u');
+        assertNearestCommonAncestors(
+            h, [xi, yi], [zi, ui],
+            'Expected the ncas of X and Y to be Z and U')
+      });
+
+      test('nca of X, Y, and Z is Z', function() {
+        const h = createHierarchy();
+        const xi = new TypeInstantiation('x');
+        const yi = new TypeInstantiation('y');
+        const zi = new TypeInstantiation('z');
+        assertNearestCommonAncestors(
+            h, [xi, yi, zi], [zi],
+            'Expected the nca of X, Y and Z to be Z')
+      });
+
+      test('nca of X, Y, and W is W', function() {
+        const h = createHierarchy();
+        const xi = new TypeInstantiation('x');
+        const yi = new TypeInstantiation('y');
+        const wi = new TypeInstantiation('w');
+        assertNearestCommonAncestors(
+            h, [xi, yi, wi], [wi],
+            'Expected the nca of X, Y and W to be W')
+      });
+
+      test('ncas of X, Y, and V are W and U', function() {
+        const h = createHierarchy();
+        const xi = new TypeInstantiation('x');
+        const yi = new TypeInstantiation('y');
+        const vi = new TypeInstantiation('v');
+        const wi = new TypeInstantiation('w');
+        const ui = new TypeInstantiation('u');
+        assertNearestCommonAncestors(
+            h, [xi, yi, vi], [wi, ui],
+            'Expected the ncas of X, Y and V to be W and U')
+      });
+
+      test('nca of X, Y, and Q is U', function () {
+        const h = createHierarchy();
+        const xi = new TypeInstantiation('x');
+        const yi = new TypeInstantiation('y');
+        const qi = new TypeInstantiation('q');
+        const ui = new TypeInstantiation('u');
+        assertNearestCommonAncestors(
+            h, [xi, yi, qi], [ui],
+            'Expected the nca of X, Y and Q to be U')
+      });
+    });
+  });
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,7 +3,8 @@
     "outDir": "build",
     "target": "es5",
     "sourceMap": true,
-    "lib": ["es6", "dom"]
+    "lib": ["es6", "dom"],
+    "downlevelIteration": true
   },
   "include": [
     "src", "test",


### PR DESCRIPTION
### :clap: Resolves

<!-- The github issue this PR is for. If this PR closes the issue please
     put the word "Closes" before the issue -->
     
N/A
     
### :star2: Description

<!-- A description of what your PR does -->
Adds support for finding the nearest common ancestor of an array of explicit types. If no common ancestors can be found, an empty array is returned.

This algorithm requires a pre-processing step which is handled when finalize() is called on the type hierarchy.

### :bug: Testing

<!-- A list of steps you used for testing, or a list of unit tests you added. -->
Tests for a bunch of common relations between types, plus some more complex relations that I got from the same research paper where I got the algorithm.

### :thought_balloon: Other info

<!-- Links to other relevant issues, pull requests, or information -->
N/A