### PR TITLE
ci: reduce node versions for mutation CI

### DIFF
--- a/.github/workflows/schedule.yaml
+++ b/.github/workflows/schedule.yaml
@@ -10,7 +10,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [12.x, 14.x, 16.x]
+        node-version: [16.x]
 
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
### :clap: Resolves

Reduces the versions the mutation CI is running on to save workflow minutes.