### PR TITLE
feat: add support for simple generic subtyping, nca, and ncd

### DIFF
--- a/src/type_definition.ts
+++ b/src/type_definition.ts
@@ -6,7 +6,7 @@
 
 import {ParameterDefinition} from './parameter_definition';
 import {TypeHierarchy} from './type_hierarchy';
-import {TypeInstantiation} from './type_instantiation';
+import {ExplicitInstantiation, TypeInstantiation} from './type_instantiation';
 import {IncompatibleType} from './exceptions';
 
 export class TypeDefinition {
@@ -92,7 +92,7 @@ export class TypeDefinition {
         p => this.hierarchy.getTypeDef(p.name).addDescendant(t));
   }
 
-  createInstance(): TypeInstantiation {
-    return new TypeInstantiation(this.name);
+  createInstance(): ExplicitInstantiation{
+    return new ExplicitInstantiation(this.name);
   }
 }

--- a/src/type_hierarchy.ts
+++ b/src/type_hierarchy.ts
@@ -5,7 +5,7 @@
  */
 
 import {TypeDefinition} from './type_definition';
-import {GenericInstantiation, TypeInstantiation} from './type_instantiation';
+import {ExplicitInstantiation, GenericInstantiation, TypeInstantiation} from './type_instantiation';
 import {removeDuplicates} from './utils';
 import {NotFinalized} from './exceptions';
 
@@ -216,7 +216,10 @@ export class TypeHierarchy {
       ...types: TypeInstantiation[]
   ): TypeInstantiation[] {
     if (!this.finalized) throw new NotFinalized();
-    if (types.length < 2) return types;
+    if (types.length == 0) return [];
+    types = types.filter(t => t instanceof ExplicitInstantiation);
+    if (types.length == 0) return [new GenericInstantiation()];
+    if (types.length == 1) return types;
 
     return types.reduce(
         (ncas, type) =>
@@ -229,7 +232,10 @@ export class TypeHierarchy {
       ...types: TypeInstantiation[]
   ): TypeInstantiation[] {
     if (!this.finalized) throw new NotFinalized();
-    if (types.length < 2) return types;
+    if (types.length == 0) return [];
+    types = types.filter(t => t instanceof ExplicitInstantiation);
+    if (types.length == 0) return [new GenericInstantiation()];
+    if (types.length == 1) return types;
 
     return types.reduce(
       (ncds, type) =>

--- a/src/type_hierarchy.ts
+++ b/src/type_hierarchy.ts
@@ -5,7 +5,7 @@
  */
 
 import {TypeDefinition} from './type_definition';
-import {TypeInstantiation} from './type_instantiation';
+import {GenericInstantiation, TypeInstantiation} from './type_instantiation';
 import {removeDuplicates} from './utils';
 import {NotFinalized} from './exceptions';
 
@@ -205,6 +205,10 @@ export class TypeHierarchy {
    * relationships within this type hierarchy.
    */
   typeFulfillsType(a: TypeInstantiation, b: TypeInstantiation): boolean {
+    if (a instanceof GenericInstantiation ||
+        b instanceof GenericInstantiation) {
+      return true;
+    }
     return this.typeDefsMap.get(a.name).hasAncestor(b);
   }
 

--- a/src/type_instantiation.ts
+++ b/src/type_instantiation.ts
@@ -4,40 +4,64 @@
  * SPDX-License-Identifier: MIT
  */
 
-export class TypeInstantiation {
+export interface TypeInstantiation {
   readonly name: string;
-  readonly isGeneric: boolean;
+  equals: (t: TypeInstantiation) => boolean;
+  clone: () => TypeInstantiation;
+}
+
+export class ExplicitInstantiation implements TypeInstantiation {
+  readonly name: string;
   readonly params: readonly TypeInstantiation[];
   readonly hasParams: boolean;
 
-  constructor(
-      name: string,
-      isGeneric = false,
-      params: TypeInstantiation[] = []
-  ) {
+  constructor(name: string, params: TypeInstantiation[] = []) {
     this.name = name;
-    this.isGeneric = isGeneric;
     this.params = params;
     this.hasParams = !!params.length;
   }
 
   /**
-   * Returns true if this type instance has the same name, generic status, and
-   * parameters of the provided type instance. Otherwise false.
+   * Returns true if this type instance has the same name and parameters of the
+   * provided type instance. Otherwise false.
    */
   equals(b: TypeInstantiation): boolean {
-    return this.name === b.name &&
-        this.isGeneric === b.isGeneric &&
-        this.params.length === b.params.length &&
-        this.params.every((p, i) => p.equals(b.params[i]));
+    return b instanceof ExplicitInstantiation &&
+      this.name === b.name &&
+      this.params.length === b.params.length &&
+      this.params.every((p, i) => p.equals(b.params[i]));
   }
 
   /**
-   * Returns a new type instance which has the an identical name, generic
-   * status, and parameters to this type instance.
+   * Returns a new type instance which has the an identical name and parameters
+   * to this type instance.
    */
   clone(): TypeInstantiation {
-    return new TypeInstantiation(
-        this.name, this.isGeneric, this.params.map(p => p.clone()));
+    return new ExplicitInstantiation(
+      this.name, this.params.map(p => p.clone()));
+  }
+}
+
+export class GenericInstantiation implements TypeInstantiation {
+  readonly name: string;
+
+  constructor(name = "") {
+    this.name = name;
+  }
+
+  /**
+   * Returns true if this type instance has the same name as the provided type
+   * instance. Otherwise false.
+   */
+  equals(b: TypeInstantiation): boolean {
+    return b instanceof GenericInstantiation && this.name === b.name;
+  }
+
+  /**
+   * Returns a new type instance which has the an identical name to this type
+   * instance.
+   */
+  clone(): TypeInstantiation {
+    return new GenericInstantiation(this.name);
   }
 }

--- a/test/nearest_common_ancestors.mocha.js
+++ b/test/nearest_common_ancestors.mocha.js
@@ -5,7 +5,7 @@
  */
 
 import {TypeHierarchy} from '../src/type_hierarchy';
-import {TypeInstantiation} from '../src/type_instantiation';
+import {ExplicitInstantiation} from '../src/type_instantiation';
 import {assert} from 'chai';
 import {NotFinalized} from '../src/exceptions';
 
@@ -16,9 +16,9 @@ suite('Nearest common ancestors', function() {
      * ancestors eas.
      * @param {!TypeHierarchy} h The hierarchy to use to find the nearest common
      *     ancestors.
-     * @param {!Array<TypeInstantiation>} ts The types to find the nearest
+     * @param {!Array<ExplicitInstantiation>} ts The types to find the nearest
      *     common ancestors of.
-     * @param {!Array<!TypeInstantiation>} eas The expected ancestors.
+     * @param {!Array<!ExplicitInstantiation>} eas The expected ancestors.
      * @param {string} msg The message to include in the assertion.
      */
     function assertNearestCommonAncestors(h, ts, eas, msg) {
@@ -49,7 +49,7 @@ suite('Nearest common ancestors', function() {
       const h = new TypeHierarchy();
       h.addTypeDef('t');
       h.finalize();
-      const ti = new TypeInstantiation('t');
+      const ti = new ExplicitInstantiation('t');
 
       assertNearestCommonAncestors(
           h, [ti], [ti], 'Expected the nca of one type to be itself');
@@ -59,8 +59,8 @@ suite('Nearest common ancestors', function() {
       const h = new TypeHierarchy();
       h.addTypeDef('a');
       h.addTypeDef('b');
-      const ai = new TypeInstantiation('a');
-      const bi = new TypeInstantiation('b');
+      const ai = new ExplicitInstantiation('a');
+      const bi = new ExplicitInstantiation('b');
       h.finalize();
 
       assert.isEmpty(
@@ -71,8 +71,8 @@ suite('Nearest common ancestors', function() {
     test('nca of a type and itself is itself', function() {
       const h = new TypeHierarchy();
       h.addTypeDef('t');
-      const ti1 = new TypeInstantiation('t');
-      const ti2 = new TypeInstantiation('t');
+      const ti1 = new ExplicitInstantiation('t');
+      const ti2 = new ExplicitInstantiation('t');
       h.finalize();
 
       assertNearestCommonAncestors(
@@ -84,8 +84,8 @@ suite('Nearest common ancestors', function() {
       const h = new TypeHierarchy();
       const td = h.addTypeDef('t');
       h.addTypeDef('p');
-      const ti = new TypeInstantiation('t');
-      const pi = new TypeInstantiation('p');
+      const ti = new ExplicitInstantiation('t');
+      const pi = new ExplicitInstantiation('p');
       td.addParent(pi);
       h.finalize();
 
@@ -99,9 +99,9 @@ suite('Nearest common ancestors', function() {
       const td = h.addTypeDef('t');
       const pd = h.addTypeDef('p');
       h.addTypeDef('gp');
-      const ti = new TypeInstantiation('t');
-      const pi = new TypeInstantiation('p');
-      const gpi = new TypeInstantiation('gp');
+      const ti = new ExplicitInstantiation('t');
+      const pi = new ExplicitInstantiation('p');
+      const gpi = new ExplicitInstantiation('gp');
       pd.addParent(gpi);
       td.addParent(pi);
       h.finalize();
@@ -117,9 +117,9 @@ suite('Nearest common ancestors', function() {
           const td = h.addTypeDef('t');
           const pd = h.addTypeDef('p');
           h.addTypeDef('gp');
-          const ti = new TypeInstantiation('t');
-          const pi = new TypeInstantiation('p');
-          const gpi = new TypeInstantiation('gp');
+          const ti = new ExplicitInstantiation('t');
+          const pi = new ExplicitInstantiation('p');
+          const gpi = new ExplicitInstantiation('gp');
           pd.addParent(gpi);
           td.addParent(pi);
           h.finalize();
@@ -134,9 +134,9 @@ suite('Nearest common ancestors', function() {
       const ad = h.addTypeDef('a');
       const bd = h.addTypeDef('b');
       h.addTypeDef('p');
-      const ai = new TypeInstantiation('a');
-      const bi = new TypeInstantiation('b');
-      const pi = new TypeInstantiation('p');
+      const ai = new ExplicitInstantiation('a');
+      const bi = new ExplicitInstantiation('b');
+      const pi = new ExplicitInstantiation('p');
       ad.addParent(pi);
       bd.addParent(pi);
       h.finalize();
@@ -152,10 +152,10 @@ suite('Nearest common ancestors', function() {
       const bd = h.addTypeDef('b');
       const cd = h.addTypeDef('c');
       h.addTypeDef('p');
-      const ai = new TypeInstantiation('a');
-      const bi = new TypeInstantiation('b');
-      const ci = new TypeInstantiation('c');
-      const pi = new TypeInstantiation('p');
+      const ai = new ExplicitInstantiation('a');
+      const bi = new ExplicitInstantiation('b');
+      const ci = new ExplicitInstantiation('c');
+      const pi = new ExplicitInstantiation('p');
       ad.addParent(pi);
       bd.addParent(pi);
       cd.addParent(pi);
@@ -173,11 +173,11 @@ suite('Nearest common ancestors', function() {
       const pbd = h.addTypeDef('pb');
       const cad = h.addTypeDef('ca');
       const cbd = h.addTypeDef('cb');
-      const gpi = new TypeInstantiation('gp');
-      const pai = new TypeInstantiation('pa');
-      const pbi = new TypeInstantiation('pb');
-      const cai = new TypeInstantiation('ca');
-      const cbi = new TypeInstantiation('cb');
+      const gpi = new ExplicitInstantiation('gp');
+      const pai = new ExplicitInstantiation('pa');
+      const pbi = new ExplicitInstantiation('pb');
+      const cai = new ExplicitInstantiation('ca');
+      const cbi = new ExplicitInstantiation('cb');
       pad.addParent(gpi);
       pbd.addParent(gpi);
       cad.addParent(pai);
@@ -195,10 +195,10 @@ suite('Nearest common ancestors', function() {
       const pad = h.addTypeDef('pa');
       const pbd = h.addTypeDef('pb');
       const cd = h.addTypeDef('c');
-      const gpi = new TypeInstantiation('gp');
-      const pai = new TypeInstantiation('pa');
-      const pbi = new TypeInstantiation('pb');
-      const ci = new TypeInstantiation('c');
+      const gpi = new ExplicitInstantiation('gp');
+      const pai = new ExplicitInstantiation('pa');
+      const pbi = new ExplicitInstantiation('pb');
+      const ci = new ExplicitInstantiation('c');
       pad.addParent(gpi);
       pbd.addParent(gpi);
       cd.addParent(pai);
@@ -216,10 +216,10 @@ suite('Nearest common ancestors', function() {
           h.addTypeDef('pb');
           const cad = h.addTypeDef('ca');
           const cbd = h.addTypeDef('cb');
-          const pai = new TypeInstantiation('pa');
-          const pbi = new TypeInstantiation('pb');
-          const cai = new TypeInstantiation('ca');
-          const cbi = new TypeInstantiation('cb');
+          const pai = new ExplicitInstantiation('pa');
+          const pbi = new ExplicitInstantiation('pb');
+          const cai = new ExplicitInstantiation('ca');
+          const cbi = new ExplicitInstantiation('cb');
           cad.addParent(pai);
           cad.addParent(pbi);
           cbd.addParent(pai);
@@ -240,12 +240,12 @@ suite('Nearest common ancestors', function() {
           h.addTypeDef('pd');
           const cad = h.addTypeDef('ca');
           const cbd = h.addTypeDef('cb');
-          const pai = new TypeInstantiation('pa');
-          const pbi = new TypeInstantiation('pb');
-          const pci = new TypeInstantiation('pc');
-          const pdi = new TypeInstantiation('pd');
-          const cai = new TypeInstantiation('ca');
-          const cbi = new TypeInstantiation('cb');
+          const pai = new ExplicitInstantiation('pa');
+          const pbi = new ExplicitInstantiation('pb');
+          const pci = new ExplicitInstantiation('pc');
+          const pdi = new ExplicitInstantiation('pd');
+          const cai = new ExplicitInstantiation('ca');
+          const cbi = new ExplicitInstantiation('cb');
           cad.addParent(pai);
           cad.addParent(pbi);
           cad.addParent(pci);
@@ -270,14 +270,14 @@ suite('Nearest common ancestors', function() {
           const cad = h.addTypeDef('ca');
           const cbd = h.addTypeDef('cb');
           const ccd = h.addTypeDef('cc');
-          const pai = new TypeInstantiation('pa');
-          const pbi = new TypeInstantiation('pb');
-          const pci = new TypeInstantiation('pc');
-          const pdi = new TypeInstantiation('pd');
-          const pei = new TypeInstantiation('pe');
-          const cai = new TypeInstantiation('ca');
-          const cbi = new TypeInstantiation('cb');
-          const cci = new TypeInstantiation('cc');
+          const pai = new ExplicitInstantiation('pa');
+          const pbi = new ExplicitInstantiation('pb');
+          const pci = new ExplicitInstantiation('pc');
+          const pdi = new ExplicitInstantiation('pd');
+          const pei = new ExplicitInstantiation('pe');
+          const cai = new ExplicitInstantiation('ca');
+          const cbi = new ExplicitInstantiation('cb');
+          const cci = new ExplicitInstantiation('cc');
           cad.addParent(pai);
           cad.addParent(pbi);
           cad.addParent(pci);
@@ -318,11 +318,11 @@ suite('Nearest common ancestors', function() {
         const xd = h.addTypeDef('x');
         const yd = h.addTypeDef('y');
         const zd = h.addTypeDef('z');
-        const qi = new TypeInstantiation('q');
-        const ui = new TypeInstantiation('u');
-        const vi = new TypeInstantiation('v');
-        const wi = new TypeInstantiation('w');
-        const zi = new TypeInstantiation('z');
+        const qi = new ExplicitInstantiation('q');
+        const ui = new ExplicitInstantiation('u');
+        const vi = new ExplicitInstantiation('v');
+        const wi = new ExplicitInstantiation('w');
+        const zi = new ExplicitInstantiation('z');
 
         qd.addParent(ui);
         vd.addParent(ui);
@@ -342,10 +342,10 @@ suite('Nearest common ancestors', function() {
 
       test('ncas of X and Y are Z and U', function() {
         const h = createHierarchy();
-        const xi = new TypeInstantiation('x');
-        const yi = new TypeInstantiation('y');
-        const zi = new TypeInstantiation('z');
-        const ui = new TypeInstantiation('u');
+        const xi = new ExplicitInstantiation('x');
+        const yi = new ExplicitInstantiation('y');
+        const zi = new ExplicitInstantiation('z');
+        const ui = new ExplicitInstantiation('u');
         assertNearestCommonAncestors(
             h, [xi, yi], [ui, zi],
             'Expected the ncas of X and Y to be Z and U');
@@ -353,9 +353,9 @@ suite('Nearest common ancestors', function() {
 
       test('nca of X, Y, and Z is Z', function() {
         const h = createHierarchy();
-        const xi = new TypeInstantiation('x');
-        const yi = new TypeInstantiation('y');
-        const zi = new TypeInstantiation('z');
+        const xi = new ExplicitInstantiation('x');
+        const yi = new ExplicitInstantiation('y');
+        const zi = new ExplicitInstantiation('z');
         assertNearestCommonAncestors(
             h, [xi, yi, zi], [zi],
             'Expected the nca of X, Y and Z to be Z');
@@ -363,9 +363,9 @@ suite('Nearest common ancestors', function() {
 
       test('nca of X, Y, and W is W', function() {
         const h = createHierarchy();
-        const xi = new TypeInstantiation('x');
-        const yi = new TypeInstantiation('y');
-        const wi = new TypeInstantiation('w');
+        const xi = new ExplicitInstantiation('x');
+        const yi = new ExplicitInstantiation('y');
+        const wi = new ExplicitInstantiation('w');
         assertNearestCommonAncestors(
             h, [xi, yi, wi], [wi],
             'Expected the nca of X, Y and W to be W');
@@ -373,11 +373,11 @@ suite('Nearest common ancestors', function() {
 
       test('ncas of X, Y, and V are W and U', function() {
         const h = createHierarchy();
-        const xi = new TypeInstantiation('x');
-        const yi = new TypeInstantiation('y');
-        const vi = new TypeInstantiation('v');
-        const wi = new TypeInstantiation('w');
-        const ui = new TypeInstantiation('u');
+        const xi = new ExplicitInstantiation('x');
+        const yi = new ExplicitInstantiation('y');
+        const vi = new ExplicitInstantiation('v');
+        const wi = new ExplicitInstantiation('w');
+        const ui = new ExplicitInstantiation('u');
         assertNearestCommonAncestors(
             h, [xi, yi, vi], [ui, wi],
             'Expected the ncas of X, Y and V to be W and U');
@@ -385,10 +385,10 @@ suite('Nearest common ancestors', function() {
 
       test('nca of X, Y, and Q is U', function() {
         const h = createHierarchy();
-        const xi = new TypeInstantiation('x');
-        const yi = new TypeInstantiation('y');
-        const qi = new TypeInstantiation('q');
-        const ui = new TypeInstantiation('u');
+        const xi = new ExplicitInstantiation('x');
+        const yi = new ExplicitInstantiation('y');
+        const qi = new ExplicitInstantiation('q');
+        const ui = new ExplicitInstantiation('u');
         assertNearestCommonAncestors(
             h, [xi, yi, qi], [ui],
             'Expected the nca of X, Y and Q to be U');

--- a/test/nearest_common_descendants.mocha.js
+++ b/test/nearest_common_descendants.mocha.js
@@ -396,7 +396,7 @@ suite('Nearest common descendants', function() {
     });
   });
 
-  suite('basic generic nearest common ancestors', function() {
+  suite('basic generic nearest common descendants', function() {
     test('nca of only generics is a generic', function() {
       const h = new TypeHierarchy();
       h.finalize();

--- a/test/nearest_common_descendants.mocha.js
+++ b/test/nearest_common_descendants.mocha.js
@@ -5,7 +5,7 @@
  */
 
 import {TypeHierarchy} from '../src/type_hierarchy';
-import {TypeInstantiation} from '../src/type_instantiation';
+import {ExplicitInstantiation} from '../src/type_instantiation';
 import {assert} from 'chai';
 import {NotFinalized} from '../src/exceptions';
 
@@ -15,15 +15,14 @@ suite('Nearest common descendants', function() {
    * ancestors eds.
    * @param {!TypeHierarchy} h The hierarchy to use to find the nearest common
    *     descendants.
-   * @param {!Array<TypeInstantiation>} ts The types to find the nearest
+   * @param {!Array<ExplicitInstantiation>} ts The types to find the nearest
    *     common descendants of.
-   * @param {!Array<!TypeInstantiation>} eds The expected descendants.
+   * @param {!Array<!ExplicitInstantiation>} eds The expected descendants.
    * @param {string} msg The message to include in the assertion.
    */
   function assertNearestCommonDescendants(h, ts, eds, msg) {
     const ads = h.getNearestCommonDescendants(...ts);
     assert.equal(ads.length, eds.length, msg);
-    console.log(ads);
     assert.isTrue(ads.every((ad, i) => ad.equals(eds[i])), msg);
   }
 
@@ -50,7 +49,7 @@ suite('Nearest common descendants', function() {
       const h = new TypeHierarchy();
       h.addTypeDef('t');
       h.finalize();
-      const ti = new TypeInstantiation('t');
+      const ti = new ExplicitInstantiation('t');
 
       assertNearestCommonDescendants(
           h, [ti], [ti], 'Expected the ncd of one type to be itself');
@@ -60,8 +59,8 @@ suite('Nearest common descendants', function() {
       const h = new TypeHierarchy();
       h.addTypeDef('a');
       h.addTypeDef('b');
-      const ai = new TypeInstantiation('a');
-      const bi = new TypeInstantiation('b');
+      const ai = new ExplicitInstantiation('a');
+      const bi = new ExplicitInstantiation('b');
       h.finalize();
 
       assert.isEmpty(
@@ -72,8 +71,8 @@ suite('Nearest common descendants', function() {
     test('ncd of a type and itself is itself', function() {
       const h = new TypeHierarchy();
       h.addTypeDef('t');
-      const ti1 = new TypeInstantiation('t');
-      const ti2 = new TypeInstantiation('t');
+      const ti1 = new ExplicitInstantiation('t');
+      const ti2 = new ExplicitInstantiation('t');
       h.finalize();
 
       assertNearestCommonDescendants(
@@ -85,8 +84,8 @@ suite('Nearest common descendants', function() {
       const h = new TypeHierarchy();
       h.addTypeDef('t');
       const cd = h.addTypeDef('c');
-      const ti = new TypeInstantiation('t');
-      const ci = new TypeInstantiation('c');
+      const ti = new ExplicitInstantiation('t');
+      const ci = new ExplicitInstantiation('c');
       cd.addParent(ti);
       h.finalize();
 
@@ -100,9 +99,9 @@ suite('Nearest common descendants', function() {
       h.addTypeDef('t');
       const cd = h.addTypeDef('c');
       const gcd = h.addTypeDef('gc');
-      const ti = new TypeInstantiation('t');
-      const ci = new TypeInstantiation('c');
-      const gci = new TypeInstantiation('gc');
+      const ti = new ExplicitInstantiation('t');
+      const ci = new ExplicitInstantiation('c');
+      const gci = new ExplicitInstantiation('gc');
       cd.addParent(ti);
       gcd.addParent(ci);
       h.finalize();
@@ -118,9 +117,9 @@ suite('Nearest common descendants', function() {
           h.addTypeDef('t');
           const cd = h.addTypeDef('c');
           const gcd = h.addTypeDef('gc');
-          const ti = new TypeInstantiation('t');
-          const ci = new TypeInstantiation('c');
-          const gci = new TypeInstantiation('gc');
+          const ti = new ExplicitInstantiation('t');
+          const ci = new ExplicitInstantiation('c');
+          const gci = new ExplicitInstantiation('gc');
           cd.addParent(ti);
           gcd.addParent(ci);
           h.finalize();
@@ -135,9 +134,9 @@ suite('Nearest common descendants', function() {
       h.addTypeDef('a');
       h.addTypeDef('b');
       const cd = h.addTypeDef('c');
-      const ai = new TypeInstantiation('a');
-      const bi = new TypeInstantiation('b');
-      const ci = new TypeInstantiation('c');
+      const ai = new ExplicitInstantiation('a');
+      const bi = new ExplicitInstantiation('b');
+      const ci = new ExplicitInstantiation('c');
       cd.addParent(ai);
       cd.addParent(bi);
       h.finalize();
@@ -153,10 +152,10 @@ suite('Nearest common descendants', function() {
       h.addTypeDef('y');
       h.addTypeDef('z');
       const cd = h.addTypeDef('c');
-      const xi = new TypeInstantiation('x');
-      const yi = new TypeInstantiation('y');
-      const zi = new TypeInstantiation('z');
-      const ci = new TypeInstantiation('c');
+      const xi = new ExplicitInstantiation('x');
+      const yi = new ExplicitInstantiation('y');
+      const zi = new ExplicitInstantiation('z');
+      const ci = new ExplicitInstantiation('c');
       cd.addParent(xi);
       cd.addParent(yi);
       cd.addParent(zi);
@@ -174,11 +173,11 @@ suite('Nearest common descendants', function() {
       const pbd = h.addTypeDef('pb');
       h.addTypeDef('gpa');
       h.addTypeDef('gpb');
-      const ci = new TypeInstantiation('c');
-      const pai = new TypeInstantiation('pa');
-      const pbi = new TypeInstantiation('pb');
-      const gpai = new TypeInstantiation('gpa');
-      const gpbi = new TypeInstantiation('gpb');
+      const ci = new ExplicitInstantiation('c');
+      const pai = new ExplicitInstantiation('pa');
+      const pbi = new ExplicitInstantiation('pb');
+      const gpai = new ExplicitInstantiation('gpa');
+      const gpbi = new ExplicitInstantiation('gpb');
       cd.addParent(pai);
       cd.addParent(pbi);
       pad.addParent(gpai);
@@ -196,10 +195,10 @@ suite('Nearest common descendants', function() {
       const pad = h.addTypeDef('pa');
       const pbd = h.addTypeDef('pb');
       h.addTypeDef('gpa');
-      const ci = new TypeInstantiation('c');
-      const pai = new TypeInstantiation('pa');
-      const pbi = new TypeInstantiation('pb');
-      const gpai = new TypeInstantiation('gpa');
+      const ci = new ExplicitInstantiation('c');
+      const pai = new ExplicitInstantiation('pa');
+      const pbi = new ExplicitInstantiation('pb');
+      const gpai = new ExplicitInstantiation('gpa');
       cd.addParent(pai);
       cd.addParent(pbi);
       pad.addParent(gpai);
@@ -217,10 +216,10 @@ suite('Nearest common descendants', function() {
           h.addTypeDef('pb');
           const cad = h.addTypeDef('ca');
           const cbd = h.addTypeDef('cb');
-          const pai = new TypeInstantiation('pa');
-          const pbi = new TypeInstantiation('pb');
-          const cai = new TypeInstantiation('ca');
-          const cbi = new TypeInstantiation('cb');
+          const pai = new ExplicitInstantiation('pa');
+          const pbi = new ExplicitInstantiation('pb');
+          const cai = new ExplicitInstantiation('ca');
+          const cbi = new ExplicitInstantiation('cb');
           cad.addParent(pai);
           cad.addParent(pbi);
           cbd.addParent(pai);
@@ -241,10 +240,10 @@ suite('Nearest common descendants', function() {
           const cbd = h.addTypeDef('cb');
           const ccd = h.addTypeDef('cc');
           const cdd = h.addTypeDef('cd');
-          const pai = new TypeInstantiation('pa');
-          const pbi = new TypeInstantiation('pb');
-          const cbi = new TypeInstantiation('cb');
-          const cci = new TypeInstantiation('cc');
+          const pai = new ExplicitInstantiation('pa');
+          const pbi = new ExplicitInstantiation('pb');
+          const cbi = new ExplicitInstantiation('cb');
+          const cci = new ExplicitInstantiation('cc');
           cad.addParent(pai);
           cbd.addParent(pai);
           cbd.addParent(pbi);
@@ -270,10 +269,10 @@ suite('Nearest common descendants', function() {
           h.addTypeDef('pa');
           h.addTypeDef('pb');
           h.addTypeDef('pc');
-          const cci = new TypeInstantiation('cc');
-          const pai = new TypeInstantiation('pa');
-          const pbi = new TypeInstantiation('pb');
-          const pci = new TypeInstantiation('pc');
+          const cci = new ExplicitInstantiation('cc');
+          const pai = new ExplicitInstantiation('pa');
+          const pbi = new ExplicitInstantiation('pb');
+          const pci = new ExplicitInstantiation('pc');
           cad.addParent(pai);
           cbd.addParent(pai);
           cbd.addParent(pbi);
@@ -316,11 +315,11 @@ suite('Nearest common descendants', function() {
         h.addTypeDef('x');
         h.addTypeDef('y');
         const zd = h.addTypeDef('z');
-        const qi = new TypeInstantiation('q');
-        const vi = new TypeInstantiation('v');
-        const xi = new TypeInstantiation('x');
-        const yi = new TypeInstantiation('y');
-        const zi = new TypeInstantiation('z');
+        const qi = new ExplicitInstantiation('q');
+        const vi = new ExplicitInstantiation('v');
+        const xi = new ExplicitInstantiation('x');
+        const yi = new ExplicitInstantiation('y');
+        const zi = new ExplicitInstantiation('z');
 
         zd.addParent(xi);
         wd.addParent(xi);
@@ -340,10 +339,10 @@ suite('Nearest common descendants', function() {
 
       test('ncds of X and Y are Z and U', function() {
         const h = createHierarchy();
-        const xi = new TypeInstantiation('x');
-        const yi = new TypeInstantiation('y');
-        const zi = new TypeInstantiation('z');
-        const ui = new TypeInstantiation('u');
+        const xi = new ExplicitInstantiation('x');
+        const yi = new ExplicitInstantiation('y');
+        const zi = new ExplicitInstantiation('z');
+        const ui = new ExplicitInstantiation('u');
         assertNearestCommonDescendants(
             h, [xi, yi], [zi, ui],
             'Expected the ncds of X and Y to be Z and U');
@@ -351,9 +350,9 @@ suite('Nearest common descendants', function() {
 
       test('ncd of X, Y, and Z is Z', function() {
         const h = createHierarchy();
-        const xi = new TypeInstantiation('x');
-        const yi = new TypeInstantiation('y');
-        const zi = new TypeInstantiation('z');
+        const xi = new ExplicitInstantiation('x');
+        const yi = new ExplicitInstantiation('y');
+        const zi = new ExplicitInstantiation('z');
         assertNearestCommonDescendants(
             h, [xi, yi, zi], [zi],
             'Expected the ncd of X, Y and Z to be Z');
@@ -361,9 +360,9 @@ suite('Nearest common descendants', function() {
 
       test('ncd of X, Y, and W is W', function() {
         const h = createHierarchy();
-        const xi = new TypeInstantiation('x');
-        const yi = new TypeInstantiation('y');
-        const wi = new TypeInstantiation('w');
+        const xi = new ExplicitInstantiation('x');
+        const yi = new ExplicitInstantiation('y');
+        const wi = new ExplicitInstantiation('w');
         assertNearestCommonDescendants(
             h, [xi, yi, wi], [wi],
             'Expected the ncd of X, Y and W to be W');
@@ -371,11 +370,11 @@ suite('Nearest common descendants', function() {
 
       test('ncds of X, Y, and V are W and U', function() {
         const h = createHierarchy();
-        const xi = new TypeInstantiation('x');
-        const yi = new TypeInstantiation('y');
-        const vi = new TypeInstantiation('v');
-        const wi = new TypeInstantiation('w');
-        const ui = new TypeInstantiation('u');
+        const xi = new ExplicitInstantiation('x');
+        const yi = new ExplicitInstantiation('y');
+        const vi = new ExplicitInstantiation('v');
+        const wi = new ExplicitInstantiation('w');
+        const ui = new ExplicitInstantiation('u');
         assertNearestCommonDescendants(
             h, [xi, yi, vi], [wi, ui],
             'Expected the ncds of X, Y and V to be W and U');
@@ -383,10 +382,10 @@ suite('Nearest common descendants', function() {
 
       test('ncd of X, Y, and Q is U', function() {
         const h = createHierarchy();
-        const xi = new TypeInstantiation('x');
-        const yi = new TypeInstantiation('y');
-        const qi = new TypeInstantiation('q');
-        const ui = new TypeInstantiation('u');
+        const xi = new ExplicitInstantiation('x');
+        const yi = new ExplicitInstantiation('y');
+        const qi = new ExplicitInstantiation('q');
+        const ui = new ExplicitInstantiation('u');
         assertNearestCommonDescendants(
             h, [xi, yi, qi], [ui],
             'Expected the ncd of X, Y and Q to be U');

--- a/test/nearest_common_descendants.mocha.js
+++ b/test/nearest_common_descendants.mocha.js
@@ -5,7 +5,10 @@
  */
 
 import {TypeHierarchy} from '../src/type_hierarchy';
-import {ExplicitInstantiation} from '../src/type_instantiation';
+import {
+  ExplicitInstantiation,
+  GenericInstantiation
+} from '../src/type_instantiation';
 import {assert} from 'chai';
 import {NotFinalized} from '../src/exceptions';
 
@@ -390,6 +393,36 @@ suite('Nearest common descendants', function() {
             h, [xi, yi, qi], [ui],
             'Expected the ncd of X, Y and Q to be U');
       });
+    });
+  });
+
+  suite('basic generic nearest common ancestors', function() {
+    test('nca of only generics is a generic', function() {
+      const h = new TypeHierarchy();
+      h.finalize();
+      const g1 = new GenericInstantiation('g1');
+      const g2 = new GenericInstantiation('g2');
+      const g3 = new GenericInstantiation('g3');
+      const g = new GenericInstantiation();
+
+      assertNearestCommonDescendants(
+          h, [g1, g2, g3], [g],
+          'Expected the ncd of only generics to be a generic');
+    });
+
+    test('generics are otherwise ignored', function() {
+      const h = new TypeHierarchy();
+      h.addTypeDef('t');
+      const cd = h.addTypeDef('c');
+      const ti = new ExplicitInstantiation('t');
+      const ci = new ExplicitInstantiation('c');
+      const gi = new GenericInstantiation('g');
+      cd.addParent(ti);
+      h.finalize();
+
+      assertNearestCommonDescendants(
+          h, [ti, ci, gi], [ci],
+          'Expected generics to be ignored when included with explicits');
     });
   });
 });

--- a/test/subtyping.mocha.js
+++ b/test/subtyping.mocha.js
@@ -5,7 +5,10 @@
  */
 
 import {TypeHierarchy} from '../src/type_hierarchy';
-import {ExplicitInstantiation} from '../src/type_instantiation';
+import {
+  ExplicitInstantiation,
+  GenericInstantiation
+} from '../src/type_instantiation';
 import {assert} from 'chai';
 
 suite('Subtyping', function() {
@@ -121,4 +124,39 @@ suite('Subtyping', function() {
           'Expected coparent types to not fulfill each other');
     });
   });
+
+  suite('basic generic subtyping', function() {
+    test('generics fulfill all types', function() {
+      const h = new TypeHierarchy();
+      h.addTypeDef('t');
+      const t = new ExplicitInstantiation('t');
+      const g = new GenericInstantiation('g');
+
+      assert.isTrue(
+          h.typeFulfillsType(g, t),
+          'Expected the generic type to fulfill the explicit type');
+    });
+
+    test('all types fulfill generics', function() {
+      const h = new TypeHierarchy();
+      h.addTypeDef('t');
+      const t = new ExplicitInstantiation('t');
+      const g = new GenericInstantiation('g');
+
+      assert.isTrue(
+          h.typeFulfillsType(t, g),
+          'Expected the explicit type to fulfill the generic type');
+    });
+
+    test('generics fulfill each other', function() {
+      const h = new TypeHierarchy();
+      h.addTypeDef('t');
+      const g1 = new GenericInstantiation('g1');
+      const g2 = new GenericInstantiation('g2');
+
+      assert.isTrue(
+          h.typeFulfillsType(g1, g2),
+          'Expected the generic types to fulfill each other');
+    });
+  })
 })

--- a/test/subtyping.mocha.js
+++ b/test/subtyping.mocha.js
@@ -5,7 +5,7 @@
  */
 
 import {TypeHierarchy} from '../src/type_hierarchy';
-import {TypeInstantiation} from '../src/type_instantiation';
+import {ExplicitInstantiation} from '../src/type_instantiation';
 import {assert} from 'chai';
 
 suite('Subtyping', function() {
@@ -13,8 +13,8 @@ suite('Subtyping', function() {
     test('every type fulfills itself', function() {
       const h = new TypeHierarchy();
       h.addTypeDef('t');
-      const ti1 = new TypeInstantiation('t');
-      const ti2 = new TypeInstantiation('t');
+      const ti1 = new ExplicitInstantiation('t');
+      const ti2 = new ExplicitInstantiation('t');
 
       assert.isTrue(
           h.typeFulfillsType(ti1, ti2), 'Expected the type to fulfill itself');
@@ -24,8 +24,8 @@ suite('Subtyping', function() {
       const h = new TypeHierarchy();
       const cd = h.addTypeDef('c');
       h.addTypeDef('p');
-      const ci = new TypeInstantiation('c');
-      const pi = new TypeInstantiation('p');
+      const ci = new ExplicitInstantiation('c');
+      const pi = new ExplicitInstantiation('p');
       cd.addParent(pi);
 
       assert.isTrue(
@@ -37,8 +37,8 @@ suite('Subtyping', function() {
       const h = new TypeHierarchy();
       const cd = h.addTypeDef('c');
       h.addTypeDef('p');
-      const ci = new TypeInstantiation('c');
-      const pi = new TypeInstantiation('p');
+      const ci = new ExplicitInstantiation('c');
+      const pi = new ExplicitInstantiation('p');
       cd.addParent(pi);
 
       assert.isFalse(
@@ -51,9 +51,9 @@ suite('Subtyping', function() {
       const td = h.addTypeDef('t');
       const pd = h.addTypeDef('p');
       h.addTypeDef('gp');
-      const ti = new TypeInstantiation('t');
-      const pi = new TypeInstantiation('p');
-      const gpi = new TypeInstantiation('gp');
+      const ti = new ExplicitInstantiation('t');
+      const pi = new ExplicitInstantiation('p');
+      const gpi = new ExplicitInstantiation('gp');
       pd.addParent(gpi);
       td.addParent(pi);
 
@@ -67,9 +67,9 @@ suite('Subtyping', function() {
       const td = h.addTypeDef('t');
       const pd = h.addTypeDef('p');
       h.addTypeDef('gp');
-      const ti = new TypeInstantiation('t');
-      const pi = new TypeInstantiation('p');
-      const gpi = new TypeInstantiation('gp');
+      const ti = new ExplicitInstantiation('t');
+      const pi = new ExplicitInstantiation('p');
+      const gpi = new ExplicitInstantiation('gp');
       pd.addParent(gpi);
       td.addParent(pi);
 
@@ -82,8 +82,8 @@ suite('Subtyping', function() {
       const h = new TypeHierarchy();
       h.addTypeDef('a');
       h.addTypeDef('b');
-      const ai = new TypeInstantiation('a');
-      const bi = new TypeInstantiation('b');
+      const ai = new ExplicitInstantiation('a');
+      const bi = new ExplicitInstantiation('b');
 
       assert.isFalse(
           h.typeFulfillsType(ai, bi),
@@ -95,9 +95,9 @@ suite('Subtyping', function() {
       h.addTypeDef('p')
       const ad = h.addTypeDef('a');
       const bd = h.addTypeDef('b');
-      const pi = new TypeInstantiation('p');
-      const ai = new TypeInstantiation('a');
-      const bi = new TypeInstantiation('b');
+      const pi = new ExplicitInstantiation('p');
+      const ai = new ExplicitInstantiation('a');
+      const bi = new ExplicitInstantiation('b');
       ad.addParent(pi);
       bd.addParent(pi);
 
@@ -111,8 +111,8 @@ suite('Subtyping', function() {
       const cd = h.addTypeDef('c')
       h.addTypeDef('a');
       h.addTypeDef('b');
-      const ai = new TypeInstantiation('a');
-      const bi = new TypeInstantiation('b');
+      const ai = new ExplicitInstantiation('a');
+      const bi = new ExplicitInstantiation('b');
       cd.addParent(ai);
       cd.addParent(bi);
 

--- a/test/type_definition.mocha.js
+++ b/test/type_definition.mocha.js
@@ -7,7 +7,7 @@
 import {IncompatibleType} from '../src/exceptions';
 import {TypeDefinition} from '../src/type_definition';
 import {TypeHierarchy} from '../src/type_hierarchy';
-import {TypeInstantiation} from '../src/type_instantiation';
+import {ExplicitInstantiation} from '../src/type_instantiation';
 import {assert} from 'chai';
 
 suite('TypeDefinition', function() {
@@ -16,7 +16,7 @@ suite('TypeDefinition', function() {
     const t = h.addTypeDef('t');
 
     assert.isTrue(
-        t.hasAncestor(new TypeInstantiation('t')),
+        t.hasAncestor(new ExplicitInstantiation('t')),
         'Expected the type definition to be an ancestor of itself');
   });
 
@@ -25,7 +25,7 @@ suite('TypeDefinition', function() {
     const t = h.addTypeDef('t');
 
     assert.isTrue(
-        t.hasDescendant(new TypeInstantiation('t')),
+        t.hasDescendant(new ExplicitInstantiation('t')),
         'Expected the type definition to be a descendant of itself');
   });
 
@@ -34,8 +34,8 @@ suite('TypeDefinition', function() {
       const h = new TypeHierarchy();
       const cd = h.addTypeDef('c');
       const pd = h.addTypeDef('p');
-      const ci = new TypeInstantiation('c');
-      const pi = new TypeInstantiation('p');
+      const ci = new ExplicitInstantiation('c');
+      const pi = new ExplicitInstantiation('p');
 
       cd.addParent(pi);
 
@@ -52,7 +52,7 @@ suite('TypeDefinition', function() {
     test('if the parent does not exist, an error is thrown', function() {
       const h = new TypeHierarchy();
       const cd = h.addTypeDef('c');
-      const pi = new TypeInstantiation('p');
+      const pi = new ExplicitInstantiation('p');
 
       assert.throws(
           () => cd.addParent(pi),
@@ -65,9 +65,9 @@ suite('TypeDefinition', function() {
       const h = new TypeHierarchy();
       const cd = h.addTypeDef('c');
       const pd = h.addTypeDef('p');
-      const pi1 = new TypeInstantiation('p');
-      const pi2 = new TypeInstantiation('p');
-      const ci = new TypeInstantiation('c')
+      const pi1 = new ExplicitInstantiation('p');
+      const pi2 = new ExplicitInstantiation('p');
+      const ci = new ExplicitInstantiation('c')
       cd.addParent(pi1);
 
       cd.addParent(pi2);
@@ -87,9 +87,9 @@ suite('TypeDefinition', function() {
       const td = h.addTypeDef('t');
       const pd = h.addTypeDef('p');
       const gpd = h.addTypeDef('gp');
-      const ti = new TypeInstantiation('t');
-      const pi = new TypeInstantiation('p');
-      const gpi = new TypeInstantiation('gp');
+      const ti = new ExplicitInstantiation('t');
+      const pi = new ExplicitInstantiation('p');
+      const gpi = new ExplicitInstantiation('gp');
       pd.addParent(gpi);
 
       td.addParent(pi);
@@ -114,9 +114,9 @@ suite('TypeDefinition', function() {
           const td = h.addTypeDef('t');
           const cd = h.addTypeDef('c');
           const pd = h.addTypeDef('p');
-          const ti = new TypeInstantiation('t');
-          const ci = new TypeInstantiation('c');
-          const pi = new TypeInstantiation('p');
+          const ti = new ExplicitInstantiation('t');
+          const ci = new ExplicitInstantiation('c');
+          const pi = new ExplicitInstantiation('p');
           cd.addParent(ti);
 
           td.addParent(pi);
@@ -136,10 +136,10 @@ suite('TypeDefinition', function() {
           const p1d = h.addTypeDef('p1');
           const p2d = h.addTypeDef('p2');
           const gpd = h.addTypeDef('gp');
-          const ti = new TypeInstantiation('t');
-          const p1i = new TypeInstantiation('p1');
-          const p2i = new TypeInstantiation('p2');
-          const gpi = new TypeInstantiation('gp');
+          const ti = new ExplicitInstantiation('t');
+          const p1i = new ExplicitInstantiation('p1');
+          const p2i = new ExplicitInstantiation('p2');
+          const gpi = new ExplicitInstantiation('gp');
           p1d.addParent(gpi);
           p2d.addParent(gpi);
           td.addParent(p1i);
@@ -164,10 +164,10 @@ suite('TypeDefinition', function() {
           const c1d = h.addTypeDef('c1');
           const c2d = h.addTypeDef('c2');
           const gcd = h.addTypeDef('gc');
-          const ti = new TypeInstantiation('t');
-          const c1i = new TypeInstantiation('c1');
-          const c2i = new TypeInstantiation('c2');
-          const gci = new TypeInstantiation('gc');
+          const ti = new ExplicitInstantiation('t');
+          const c1i = new ExplicitInstantiation('c1');
+          const c2i = new ExplicitInstantiation('c2');
+          const gci = new ExplicitInstantiation('gc');
           gcd.addParent(c1i);
           gcd.addParent(c2i);
           c1d.addParent(ti);

--- a/test/type_instantiation.mocha.js
+++ b/test/type_instantiation.mocha.js
@@ -4,22 +4,25 @@
  * SPDX-License-Identifier: MIT
  */
 
-import {TypeInstantiation} from '../src/type_instantiation';
+import {
+  ExplicitInstantiation,
+  GenericInstantiation
+} from '../src/type_instantiation';
 import {assert} from 'chai';
 
 suite('TypeStructure', function() {
   suite('equals is exactly equal', function() {
     test('identical names are equal', function() {
-      const a = new TypeInstantiation('test');
-      const b = new TypeInstantiation('test');
+      const a = new ExplicitInstantiation('test');
+      const b = new ExplicitInstantiation('test');
 
       assert.isTrue(
           a.equals(b), 'Expected identical TypeInstantiations to be equal');
     });
 
     test('different names are not equal', function() {
-      const a = new TypeInstantiation('test');
-      const b = new TypeInstantiation('test2');
+      const a = new ExplicitInstantiation('test');
+      const b = new ExplicitInstantiation('test2');
 
       assert.isFalse(
           a.equals(b),
@@ -27,8 +30,8 @@ suite('TypeStructure', function() {
     });
 
     test('differently cased names are not equal', function() {
-      const a = new TypeInstantiation('test');
-      const b = new TypeInstantiation('TEST');
+      const a = new ExplicitInstantiation('test');
+      const b = new ExplicitInstantiation('TEST');
 
       assert.isFalse(
           a.equals(b),
@@ -36,8 +39,8 @@ suite('TypeStructure', function() {
     });
 
     test('identical generics are equal', function() {
-      const a = new TypeInstantiation('test', true);
-      const b = new TypeInstantiation('test', true);
+      const a = new GenericInstantiation('test');
+      const b = new GenericInstantiation('test');
 
       assert.isTrue(
           a.equals(b),
@@ -45,8 +48,8 @@ suite('TypeStructure', function() {
     });
 
     test('different generics are not equal', function() {
-      const a = new TypeInstantiation('test', true);
-      const b = new TypeInstantiation('test2', true);
+      const a = new GenericInstantiation('test');
+      const b = new GenericInstantiation('test2');
 
       assert.isFalse(
           a.equals(b),
@@ -54,8 +57,8 @@ suite('TypeStructure', function() {
     });
 
     test('differently cased generics are not equal', function() {
-      const a = new TypeInstantiation('test', true);
-      const b = new TypeInstantiation('TEST', true);
+      const a = new GenericInstantiation('test');
+      const b = new GenericInstantiation('TEST');
 
       assert.isFalse(
           a.equals(b),
@@ -63,8 +66,8 @@ suite('TypeStructure', function() {
     });
 
     test('generics and non-generics are not equal', function() {
-      const a = new TypeInstantiation('test', true);
-      const b = new TypeInstantiation('test', false);
+      const a = new GenericInstantiation('test');
+      const b = new ExplicitInstantiation('test');
 
       assert.isFalse(
           a.equals(b),
@@ -72,12 +75,12 @@ suite('TypeStructure', function() {
     });
 
     test('identical params are equal', function() {
-      const p1A = new TypeInstantiation('p1');
-      const p1B = new TypeInstantiation('p1');
-      const p2A = new TypeInstantiation('p2');
-      const p2B = new TypeInstantiation('p2');
-      const a = new TypeInstantiation('test', false, [p1A, p2A]);
-      const b = new TypeInstantiation('test', false, [p1B, p2B]);
+      const p1A = new ExplicitInstantiation('p1');
+      const p1B = new ExplicitInstantiation('p1');
+      const p2A = new ExplicitInstantiation('p2');
+      const p2B = new ExplicitInstantiation('p2');
+      const a = new ExplicitInstantiation('test', [p1A, p2A]);
+      const b = new ExplicitInstantiation('test', [p1B, p2B]);
 
       assert.isTrue(
           a.equals(b),
@@ -85,11 +88,11 @@ suite('TypeStructure', function() {
     });
 
     test('different param counts are not equal', function() {
-      const p1A = new TypeInstantiation('p1');
-      const p1B = new TypeInstantiation('p1');
-      const p2A = new TypeInstantiation('p2');
-      const a = new TypeInstantiation('test', false, [p1A, p2A]);
-      const b = new TypeInstantiation('test', false, [p1B]);
+      const p1A = new ExplicitInstantiation('p1');
+      const p1B = new ExplicitInstantiation('p1');
+      const p2A = new ExplicitInstantiation('p2');
+      const a = new ExplicitInstantiation('test', [p1A, p2A]);
+      const b = new ExplicitInstantiation('test', [p1B]);
 
       assert.isFalse(
           a.equals(b),
@@ -99,22 +102,22 @@ suite('TypeStructure', function() {
 
   suite('cloning', function() {
     test('cloning a simple explicit type', function() {
-      const t = new TypeInstantiation('test');
+      const t = new ExplicitInstantiation('test');
       const c = t.clone();
 
       assert.deepEqual(c, t, 'Expected the clone to deeply equal the original');
     });
 
     test('cloning a generic type', function() {
-      const t = new TypeInstantiation('test', true);
+      const t = new GenericInstantiation('test');
       const c = t.clone();
 
       assert.deepEqual(c, t, 'Expected the clone to deeply equal the original');
     });
 
     test('cloning a parameterized type', function() {
-      const p = new TypeInstantiation('parameter');
-      const t = new TypeInstantiation('test', false, [p]);
+      const p = new ExplicitInstantiation('parameter');
+      const t = new ExplicitInstantiation('test', [p]);
       const c = t.clone();
 
       assert.deepEqual(c, t, 'Expected the clone to deeply equal the original');
@@ -123,15 +126,15 @@ suite('TypeStructure', function() {
 
   suite('having params', function() {
     test('having params', function() {
-      const p = new TypeInstantiation('p');
-      const t = new TypeInstantiation('test', false, [p]);
+      const p = new ExplicitInstantiation('p');
+      const t = new ExplicitInstantiation('test', [p]);
 
       assert.isTrue(
           t.hasParams, 'Expected the TypeInstantiation to have params');
     });
 
     test('not having params', function() {
-      const t = new TypeInstantiation('test');
+      const t = new ExplicitInstantiation('test');
 
       assert.isFalse(
           t.hasParams, 'Expected the TypeInstantiation to not have params');


### PR DESCRIPTION
### :clap: Resolves

<!-- The github issue this PR is for. If this PR closes the issue please
     put the word "Closes" before the issue -->
     
N/A
     
### :star2: Description

<!-- A description of what your PR does -->
Splites the TypeInstantiation class into two new classes: ExplicitInstantiation, and GenericInstantiation.

Adds logic in the TypeHierarchy to handle generic instantiations when determining subtyping, nearest common ancestors, and nearest common descendants.

### :bug: Testing

<!-- A list of steps you used for testing, or a list of unit tests you added. -->
Unit tests :D
Also updates a bunch of unit tests.

### :thought_balloon: Other info

<!-- Links to other relevant issues, pull requests, or information -->
N/A