### PR TITLE
feat: add subtyping for constrained generics

### DIFF
--- a/src/type_instantiation.ts
+++ b/src/type_instantiation.ts
@@ -43,14 +43,14 @@ export class ExplicitInstantiation implements TypeInstantiation {
 }
 
 export class GenericInstantiation implements TypeInstantiation {
-  readonly name: string;
+  readonly isConstrained: boolean;
 
   constructor(
-      name = '',
-      boundsType: BoundsType = undefined,
-      bounds: readonly TypeInstantiation[] = []
+      readonly name = '',
+      readonly boundsType: BoundsType = undefined,
+      readonly bounds: readonly ExplicitInstantiation[] = []
   ) {
-    this.name = name;
+    this.isConstrained = !!bounds.length;
   }
 
   /**

--- a/src/type_instantiation.ts
+++ b/src/type_instantiation.ts
@@ -45,7 +45,11 @@ export class ExplicitInstantiation implements TypeInstantiation {
 export class GenericInstantiation implements TypeInstantiation {
   readonly name: string;
 
-  constructor(name = '') {
+  constructor(
+      name = '',
+      boundsType: BoundsType = undefined,
+      bounds: readonly TypeInstantiation[] = []
+  ) {
     this.name = name;
   }
 
@@ -64,4 +68,9 @@ export class GenericInstantiation implements TypeInstantiation {
   clone(): TypeInstantiation {
     return new GenericInstantiation(this.name);
   }
+}
+
+export enum BoundsType {
+  MORE_SPECIFIC_THAN,
+  MORE_GENERAL_THAN
 }

--- a/test/subtyping.mocha.js
+++ b/test/subtyping.mocha.js
@@ -8,6 +8,7 @@ import {TypeHierarchy} from '../src/type_hierarchy';
 import {
   ExplicitInstantiation,
   GenericInstantiation,
+  BoundsType,
 } from '../src/type_instantiation';
 import {assert} from 'chai';
 
@@ -157,6 +158,504 @@ suite('Subtyping', function() {
       assert.isTrue(
           h.typeFulfillsType(g1, g2),
           'Expected the generic types to fulfill each other');
+    });
+  });
+
+  suite('constrained generic subtyping', function() {
+    test('generics always fulfill constrained generics', function() {
+      const h = new TypeHierarchy();
+      h.addTypeDef('t');
+      const ti = new ExplicitInstantiation('t');
+      const gi = new GenericInstantiation('g');
+      const ci = new GenericInstantiation(
+          'c', BoundsType.MORE_SPECIFIC_THAN, [ti]);
+
+      assert.isTrue(
+          h.typeFulfillsType(gi, ci),
+          'Expected unconstrained generics to always fulfill constrained generics');
+    });
+
+    suite('explicits fulfilling constrained generics', function() {
+      test('the same type fulfills a generic with an upper bound', function() {
+        const h = new TypeHierarchy();
+        h.addTypeDef('t');
+        const ti = new ExplicitInstantiation('t');
+        const gi = new GenericInstantiation(
+            'g', BoundsType.MORE_SPECIFIC_THAN, [ti]);
+
+        assert.isTrue(
+            h.typeFulfillsType(ti, gi),
+            'Expected the same type to fulfill a generic with an upper bound');
+      });
+
+      test('subtypes fulfill generis with a compatible upper bound', function() {
+        const h = new TypeHierarchy();
+        const td = h.addTypeDef('t');
+        h.addTypeDef('p');
+        const ti = new ExplicitInstantiation('t');
+        const pi = new ExplicitInstantiation('p');
+        const gi = new GenericInstantiation(
+            'g', BoundsType.MORE_SPECIFIC_THAN, [pi]);
+        td.addParent(pi);
+
+        assert.isTrue(
+            h.typeFulfillsType(ti, gi),
+            'Expected a subtype to fulfill a generic with an upper bound');
+      });
+
+      test('subtypes fulfill generics with multiple compatible upper bounds',
+          function() {
+            const h = new TypeHierarchy();
+            const td = h.addTypeDef('t');
+            h.addTypeDef('p1');
+            h.addTypeDef('p2');
+            const ti = new ExplicitInstantiation('t');
+            const p1i = new ExplicitInstantiation('p1');
+            const p2i = new ExplicitInstantiation('p2');
+            const gi = new GenericInstantiation(
+                'g', BoundsType.MORE_SPECIFIC_THAN, [p1i, p2i]);
+            td.addParent(p1i);
+            td.addParent(p2i);
+
+            assert.isTrue(
+                h.typeFulfillsType(ti, gi),
+                'Expected a subtype to fulfill a generic with multiple compatible upper bounds');
+          });
+
+      test('subtypes do not fulfill generics with some incompatible upper bounds',
+          function() {
+            const h = new TypeHierarchy();
+            const td = h.addTypeDef('t');
+            h.addTypeDef('p1');
+            h.addTypeDef('p2');
+            const ti = new ExplicitInstantiation('t');
+            const p1i = new ExplicitInstantiation('p1');
+            const p2i = new ExplicitInstantiation('p2');
+            const gi = new GenericInstantiation(
+                'g', BoundsType.MORE_SPECIFIC_THAN, [p1i, p2i]);
+            td.addParent(p1i);
+
+            assert.isFalse(
+                h.typeFulfillsType(ti, gi),
+                'Expected a subtype to not fulfill a generic with some incompatible upper bounds');
+          });
+
+      test('supertypes do not fulfill generics with an upper bound', function() {
+        const h = new TypeHierarchy();
+        const td = h.addTypeDef('t');
+        h.addTypeDef('p');
+        const ti = new ExplicitInstantiation('t');
+        const pi = new ExplicitInstantiation('p');
+        const gi = new GenericInstantiation(
+            'g', BoundsType.MORE_SPECIFIC_THAN, [ti]);
+        td.addParent(pi);
+
+        assert.isFalse(
+            h.typeFulfillsType(pi, gi),
+            'Expected a supertype to not fulfill a generic with an upper bound');
+      });
+
+      test('unrelated types do not fulfill generics with an upper bound',
+          function() {
+            const h = new TypeHierarchy();
+            h.addTypeDef('t');
+            h.addTypeDef('u');
+            const ti = new ExplicitInstantiation('t');
+            const ui = new ExplicitInstantiation('u');
+            const gi = new GenericInstantiation(
+                'g', BoundsType.MORE_SPECIFIC_THAN, [ti]);
+
+            assert.isFalse(
+                h.typeFulfillsType(ui, gi),
+                'Expected an unrelated type to not fulfill a generic with an upper bound');
+          });
+
+      test('the same type fulfills a generic with a lower bound', function() {
+        const h = new TypeHierarchy();
+        h.addTypeDef('t');
+        const ti = new ExplicitInstantiation('t');
+        const gi = new GenericInstantiation(
+            'g', BoundsType.MORE_GENERAL_THAN, [ti]);
+
+        assert.isTrue(
+            h.typeFulfillsType(ti, gi),
+            'Expected the same type to fulfill a generic with a lower bound');
+      });
+
+      test('supertypes fulfill generis with a compatible lower bound', function() {
+        const h = new TypeHierarchy();
+        const td = h.addTypeDef('t');
+        h.addTypeDef('p');
+        const ti = new ExplicitInstantiation('t');
+        const pi = new ExplicitInstantiation('p');
+        const gi = new GenericInstantiation(
+            'g', BoundsType.MORE_GENERAL_THAN, [ti]);
+        td.addParent(pi);
+
+        assert.isTrue(
+            h.typeFulfillsType(pi, gi),
+            'Expected a supertype to fulfill a generic with a lower bound');
+      });
+
+      test('supertypes fulfill generics with multiple compatible lower bounds',
+          function() {
+            const h = new TypeHierarchy();
+            const t1d = h.addTypeDef('t1');
+            const t2d = h.addTypeDef('t2');
+            h.addTypeDef('p');
+            const t1i = new ExplicitInstantiation('t1');
+            const t2i = new ExplicitInstantiation('t2');
+            const pi = new ExplicitInstantiation('p');
+            const gi = new GenericInstantiation(
+                'g', BoundsType.MORE_GENERAL_THAN, [t1i, t2i]);
+            t1d.addParent(pi);
+            t2d.addParent(pi);
+
+            assert.isTrue(
+                h.typeFulfillsType(pi, gi),
+                'Expected a supertype to fulfill a generic with multiple compatible lower bounds');
+          });
+
+      test('supertypes do not fulfill generics with some incompatible lower bounds',
+          function() {
+            const h = new TypeHierarchy();
+            const t1d = h.addTypeDef('t1');
+            h.addTypeDef('t2');
+            h.addTypeDef('p');
+            const t1i = new ExplicitInstantiation('t1');
+            const t2i = new ExplicitInstantiation('t2');
+            const pi = new ExplicitInstantiation('p');
+            const gi = new GenericInstantiation(
+                'g', BoundsType.MORE_GENERAL_THAN, [t1i, t2i]);
+            t1d.addParent(pi);
+
+            assert.isFalse(
+                h.typeFulfillsType(pi, gi),
+                'Expected a supertype to not fulfill a generic with some incompatible lower bounds');
+          });
+
+      test('subtypes do not fulfill generics with an lower bound', function() {
+        const h = new TypeHierarchy();
+        const td = h.addTypeDef('t');
+        h.addTypeDef('p');
+        const ti = new ExplicitInstantiation('t');
+        const pi = new ExplicitInstantiation('p');
+        const gi = new GenericInstantiation(
+            'g', BoundsType.MORE_GENERAL_THAN, [pi]);
+        td.addParent(pi);
+
+        assert.isFalse(
+            h.typeFulfillsType(ti, gi),
+            'Expected a subype to not fulfill a generic with an lower bound');
+      });
+
+      test('unrelated types do not fulfill generics with an lower bound',
+          function() {
+            const h = new TypeHierarchy();
+            h.addTypeDef('t');
+            h.addTypeDef('u');
+            const ti = new ExplicitInstantiation('t');
+            const ui = new ExplicitInstantiation('u');
+            const gi = new GenericInstantiation(
+                'g', BoundsType.MORE_GENERAL_THAN, [ti]);
+
+            assert.isTrue(
+                h.typeFulfillsType(ui, gi),
+                'Expected an unrelated type to not fulfill a generic with a lower bound');
+          });
+    });
+
+    suite('constrained generics fulfilling each other', function() {
+      test('generics with identical upper bounds fulfill each other',
+          function() {
+            const h = new TypeHierarchy();
+            h.addTypeDef('t');
+            const ti = new ExplicitInstantiation('t');
+            const gi1 = new GenericInstantiation(
+                'g', BoundsType.MORE_SPECIFIC_THAN, [ti]);
+            const gi2 = new GenericInstantiation(
+                'g', BoundsType.MORE_SPECIFIC_THAN, [ti]);
+
+            assert.isTrue(
+                h.typeFulfillsType(gi1, gi2),
+                'Expected generics with identical upper bounds to fulfill each other');
+          });
+
+      test('generics with one upper bound lower than the other fulfill each other',
+          function() {
+            const h = new TypeHierarchy();
+            const td = h.addTypeDef('t');
+            h.addTypeDef('p');
+            const ti = new ExplicitInstantiation('t');
+            const pi = new ExplicitInstantiation('p');
+            const gi1 = new GenericInstantiation(
+                'g', BoundsType.MORE_SPECIFIC_THAN, [ti]);
+            const gi2 = new GenericInstantiation(
+                'g', BoundsType.MORE_SPECIFIC_THAN, [pi]);
+            td.addParent(pi);
+
+            assert.isTrue(
+                h.typeFulfillsType(gi1, gi2),
+                'Expected generics with one upper bound lower than the other to fulfill each other');
+          });
+
+      test('generics with upper bounds that share children fulfill each other',
+          function() {
+            const h = new TypeHierarchy();
+            const td = h.addTypeDef('t');
+            h.addTypeDef('p1');
+            h.addTypeDef('p2');
+            const p1i = new ExplicitInstantiation('p1');
+            const p2i = new ExplicitInstantiation('p2');
+            const gi1 = new GenericInstantiation(
+                'g', BoundsType.MORE_SPECIFIC_THAN, [p1i]);
+            const gi2 = new GenericInstantiation(
+                'g', BoundsType.MORE_SPECIFIC_THAN, [p2i]);
+            td.addParent(p1i);
+            td.addParent(p2i);
+
+            assert.isTrue(
+                h.typeFulfillsType(gi1, gi2),
+                'Expected generics with upper bounds that share children to fulfill each other');
+          });
+
+      test('generics with unrelated upper bounds do not fulfill each other',
+          function() {
+            const h = new TypeHierarchy();
+            h.addTypeDef('t1');
+            h.addTypeDef('t2');
+            const t1i = new ExplicitInstantiation('t1');
+            const t2i = new ExplicitInstantiation('t2');
+            const gi1 = new GenericInstantiation(
+                'g', BoundsType.MORE_SPECIFIC_THAN, [t1i]);
+            const gi2 = new GenericInstantiation(
+                'g', BoundsType.MORE_SPECIFIC_THAN, [t2i]);
+
+            assert.isFalse(
+                h.typeFulfillsType(gi1, gi2),
+                'Expected generics with unrelated upper bounds to not fulfill each other');
+          });
+
+      test('T <: Animal & <: Flier fulfills G <: Mammal', function() {
+        const h = new TypeHierarchy();
+        h.addTypeDef('Animal');
+        h.addTypeDef('Flier');
+        const mammald = h.addTypeDef('Mammal');
+        const birdd = h.addTypeDef('Bird');
+        const batd = h.addTypeDef('Bat');
+        const animali = new ExplicitInstantiation('Animal');
+        const flieri = new ExplicitInstantiation('Flier');
+        const mammali = new ExplicitInstantiation('Mammal');
+        const t = new GenericInstantiation(
+            't', BoundsType.MORE_SPECIFIC_THAN, [animali, flieri]);
+        const g = new GenericInstantiation(
+            'g', BoundsType.MORE_SPECIFIC_THAN, [mammali]);
+        birdd.addParent(animali);
+        birdd.addParent(flieri);
+        mammald.addParent(animali);
+        batd.addParent(mammali);
+        batd.addParent(flieri);
+
+        assert.isTrue(
+            h.typeFulfillsType(t, g),
+            'Expected T <: Animal & <: Flier to fulfill G <: Mammal');
+      });
+
+      test('T <: Mammal fulfills G <: Animal & <: Flier', function() {
+        const h = new TypeHierarchy();
+        h.addTypeDef('Animal');
+        h.addTypeDef('Flier');
+        const mammald = h.addTypeDef('Mammal');
+        const birdd = h.addTypeDef('Bird');
+        const batd = h.addTypeDef('Bat');
+        const animali = new ExplicitInstantiation('Animal');
+        const flieri = new ExplicitInstantiation('Flier');
+        const mammali = new ExplicitInstantiation('Mammal');
+        const t = new GenericInstantiation(
+            't', BoundsType.MORE_SPECIFIC_THAN, [mammali]);
+        const g = new GenericInstantiation(
+            'g', BoundsType.MORE_SPECIFIC_THAN, [animali, flieri]);
+        birdd.addParent(animali);
+        birdd.addParent(flieri);
+        mammald.addParent(animali);
+        batd.addParent(mammali);
+        batd.addParent(flieri);
+
+        assert.isTrue(
+            h.typeFulfillsType(t, g),
+            'Expected T <: Mammal to fulfill G <: Animal & Flier');
+      });
+
+      test('generics with identical lower bounds fulfill each other',
+          function() {
+            const h = new TypeHierarchy();
+            h.addTypeDef('t');
+            const ti = new ExplicitInstantiation('t');
+            const gi1 = new GenericInstantiation(
+                'g', BoundsType.MORE_GENERAL_THAN, [ti]);
+            const gi2 = new GenericInstantiation(
+                'g', BoundsType.MORE_GENERAL_THAN, [ti]);
+
+            assert.isTrue(
+                h.typeFulfillsType(gi1, gi2),
+                'Expected generics with identical lower bounds to fulfill each other');
+          });
+
+      test('generics with one lower bound higher than the other fulfill each other',
+          function() {
+            const h = new TypeHierarchy();
+            const td = h.addTypeDef('t');
+            h.addTypeDef('p');
+            const ti = new ExplicitInstantiation('t');
+            const pi = new ExplicitInstantiation('p');
+            const gi1 = new GenericInstantiation(
+                'g', BoundsType.MORE_GENERAL_THAN, [ti]);
+            const gi2 = new GenericInstantiation(
+                'g', BoundsType.MORE_GENERAL_THAN, [pi]);
+            td.addParent(pi);
+
+            assert.isTrue(
+                h.typeFulfillsType(gi1, gi2),
+                'Expected generics with one lower bound higher than the other to fulfill each other');
+          });
+
+      test('generics with lower bounds that share parents fulfill each other',
+          function() {
+            const h = new TypeHierarchy();
+            const t1d = h.addTypeDef('t1');
+            const t2d = h.addTypeDef('t2');
+            h.addTypeDef('p');
+            const t1i = new ExplicitInstantiation('t1i');
+            const t2i = new ExplicitInstantiation('t2i');
+            const pi = new ExplicitInstantiation('p');
+            const gi1 = new GenericInstantiation(
+                'g', BoundsType.MORE_GENERAL_THAN, [t1i]);
+            const gi2 = new GenericInstantiation(
+                'g', BoundsType.MORE_GENERAL_THAN, [t2i]);
+            t1d.addParent(pi);
+            t2d.addParent(pi);
+
+            assert.isTrue(
+                h.typeFulfillsType(gi1, gi2),
+                'Expected generics with lower bounds that share parents to fulfill each other');
+          });
+
+      test('generics with unrelated lower bounds do not fulfill each other',
+          function() {
+            const h = new TypeHierarchy();
+            h.addTypeDef('t1');
+            h.addTypeDef('t2');
+            const t1i = new ExplicitInstantiation('t1');
+            const t2i = new ExplicitInstantiation('t2');
+            const gi1 = new GenericInstantiation(
+                'g', BoundsType.MORE_GENERAL_THAN, [t1i]);
+            const gi2 = new GenericInstantiation(
+                'g', BoundsType.MORE_GENERAL_THAN, [t2i]);
+
+            assert.isFalse(
+                h.typeFulfillsType(gi1, gi2),
+                'Expected generics with unrelated lower bounds to not fulfill each other');
+          });
+
+      test('generic with a lower bound lower than a generic with an upper bound fulfills the generic',
+          function() {
+            const h = new TypeHierarchy();
+            const td = h.addTypeDef('t');
+            h.addTypeDef('p');
+            const ti = new ExplicitInstantiation('t');
+            const pi = new ExplicitInstantiation('p');
+            const gi1 = new GenericInstantiation(
+                'g', BoundsType.MORE_GENERAL_THAN, [ti]);
+            const gi2 = new GenericInstantiation(
+                'g', BoundsType.MORE_SPECIFIC_THAN, [pi]);
+            td.addParent(pi);
+
+            assert.isTrue(
+                h.typeFulfillsType(gi1, gi2),
+                'Expected a generic with a lower bound lower than a generic with an upperbound to fulfill the generic');
+          });
+
+      test('generic with a lower bound compatible with both of the upper bounds fulfills the generic',
+          function() {
+            const h = new TypeHierarchy();
+            const td = h.addTypeDef('t');
+            h.addTypeDef('p1');
+            h.addTypeDef('p2');
+            const ti = new ExplicitInstantiation('t');
+            const p1i = new ExplicitInstantiation('p1');
+            const p2i = new ExplicitInstantiation('p2');
+            const gi1 = new GenericInstantiation(
+                'g', BoundsType.MORE_GENERAL_THAN, [ti]);
+            const gi2 = new GenericInstantiation(
+                'g', BoundsType.MORE_SPECIFIC_THAN, [p1i, p2i]);
+            td.addParent(p1i);
+            td.addParent(p2i);
+
+            assert.isTrue(
+                h.typeFulfillsType(gi1, gi2),
+                'Expected a generic with a lower bound compatible with both of the upper bounds to fulfill the generic');
+          });
+
+      test('generic with an upper bound compatible with both of the lower bounds fulfills the generic',
+          function() {
+            const h = new TypeHierarchy();
+            const t1d = h.addTypeDef('t1');
+            const t2d = h.addTypeDef('t2');
+            h.addTypeDef('p');
+            const t1i = new ExplicitInstantiation('t1');
+            const t2i = new ExplicitInstantiation('t2');
+            const pi = new ExplicitInstantiation('p');
+            const gi1 = new GenericInstantiation(
+                'g', BoundsType.MORE_GENERAL_THAN, [t1i, t2i]);
+            const gi2 = new GenericInstantiation(
+                'g', BoundsType.MORE_SPECIFIC_THAN, [pi]);
+            t1d.addParent(pi);
+            t2d.addParent(pi);
+
+            assert.isTrue(
+                h.typeFulfillsType(gi1, gi2),
+                'Expected a generic an upper bound compatible with bth of the lower bounds to fulfill the generic');
+          });
+
+      test('generic with a lower bound incompatible with one of the upper bounds does not fulfill the generic',
+          function() {
+            const h = new TypeHierarchy();
+            const td = h.addTypeDef('t');
+            h.addTypeDef('p1');
+            h.addTypeDef('p2');
+            const ti = new ExplicitInstantiation('t');
+            const p1i = new ExplicitInstantiation('p1');
+            const p2i = new ExplicitInstantiation('p2');
+            const gi1 = new GenericInstantiation(
+                'g', BoundsType.MORE_GENERAL_THAN, [ti]);
+            const gi2 = new GenericInstantiation(
+                'g', BoundsType.MORE_SPECIFIC_THAN, [p1i, p2i]);
+            td.addParent(p1i);
+
+            assert.isFalse(
+                h.typeFulfillsType(gi1, gi2),
+                'Expected a generic with a lower bound incompatible with one of the upperbounds to not fulfill the generic');
+          });
+
+      test('generic with an upper bound incompatible with one of the lower bounds does not fulfill the generic',
+          function() {
+            const h = new TypeHierarchy();
+            const t1d = h.addTypeDef('t1');
+            h.addTypeDef('t2');
+            h.addTypeDef('p');
+            const t1i = new ExplicitInstantiation('t1');
+            const t2i = new ExplicitInstantiation('t2');
+            const pi = new ExplicitInstantiation('p');
+            const gi1 = new GenericInstantiation(
+                'g', BoundsType.MORE_GENERAL_THAN, [t1i, t2i]);
+            const gi2 = new GenericInstantiation(
+                'g', BoundsType.MORE_SPECIFIC_THAN, [pi]);
+            t1d.addParent(pi);
+
+            assert.isFalse(
+                h.typeFulfillsType(gi1, gi2),
+                'Expected a generic an upper bound incompatible with one of the lower bounds to not fulfill the generic');
+          });
     });
   });
 });

--- a/test/subtyping.mocha.js
+++ b/test/subtyping.mocha.js
@@ -359,7 +359,7 @@ suite('Subtyping', function() {
             const gi = new GenericInstantiation(
                 'g', BoundsType.MORE_GENERAL_THAN, [ti]);
 
-            assert.isTrue(
+            assert.isFalse(
                 h.typeFulfillsType(ui, gi),
                 'Expected an unrelated type to not fulfill a generic with a lower bound');
           });
@@ -375,6 +375,7 @@ suite('Subtyping', function() {
                 'g', BoundsType.MORE_SPECIFIC_THAN, [ti]);
             const gi2 = new GenericInstantiation(
                 'g', BoundsType.MORE_SPECIFIC_THAN, [ti]);
+            h.finalize();
 
             assert.isTrue(
                 h.typeFulfillsType(gi1, gi2),
@@ -393,6 +394,7 @@ suite('Subtyping', function() {
             const gi2 = new GenericInstantiation(
                 'g', BoundsType.MORE_SPECIFIC_THAN, [pi]);
             td.addParent(pi);
+            h.finalize();
 
             assert.isTrue(
                 h.typeFulfillsType(gi1, gi2),
@@ -413,6 +415,7 @@ suite('Subtyping', function() {
                 'g', BoundsType.MORE_SPECIFIC_THAN, [p2i]);
             td.addParent(p1i);
             td.addParent(p2i);
+            h.finalize();
 
             assert.isTrue(
                 h.typeFulfillsType(gi1, gi2),
@@ -430,6 +433,7 @@ suite('Subtyping', function() {
                 'g', BoundsType.MORE_SPECIFIC_THAN, [t1i]);
             const gi2 = new GenericInstantiation(
                 'g', BoundsType.MORE_SPECIFIC_THAN, [t2i]);
+            h.finalize();
 
             assert.isFalse(
                 h.typeFulfillsType(gi1, gi2),
@@ -455,6 +459,7 @@ suite('Subtyping', function() {
         mammald.addParent(animali);
         batd.addParent(mammali);
         batd.addParent(flieri);
+        h.finalize();
 
         assert.isTrue(
             h.typeFulfillsType(t, g),
@@ -480,6 +485,7 @@ suite('Subtyping', function() {
         mammald.addParent(animali);
         batd.addParent(mammali);
         batd.addParent(flieri);
+        h.finalize();
 
         assert.isTrue(
             h.typeFulfillsType(t, g),
@@ -495,6 +501,7 @@ suite('Subtyping', function() {
                 'g', BoundsType.MORE_GENERAL_THAN, [ti]);
             const gi2 = new GenericInstantiation(
                 'g', BoundsType.MORE_GENERAL_THAN, [ti]);
+            h.finalize();
 
             assert.isTrue(
                 h.typeFulfillsType(gi1, gi2),
@@ -513,6 +520,7 @@ suite('Subtyping', function() {
             const gi2 = new GenericInstantiation(
                 'g', BoundsType.MORE_GENERAL_THAN, [pi]);
             td.addParent(pi);
+            h.finalize();
 
             assert.isTrue(
                 h.typeFulfillsType(gi1, gi2),
@@ -525,8 +533,8 @@ suite('Subtyping', function() {
             const t1d = h.addTypeDef('t1');
             const t2d = h.addTypeDef('t2');
             h.addTypeDef('p');
-            const t1i = new ExplicitInstantiation('t1i');
-            const t2i = new ExplicitInstantiation('t2i');
+            const t1i = new ExplicitInstantiation('t1');
+            const t2i = new ExplicitInstantiation('t2');
             const pi = new ExplicitInstantiation('p');
             const gi1 = new GenericInstantiation(
                 'g', BoundsType.MORE_GENERAL_THAN, [t1i]);
@@ -534,6 +542,7 @@ suite('Subtyping', function() {
                 'g', BoundsType.MORE_GENERAL_THAN, [t2i]);
             t1d.addParent(pi);
             t2d.addParent(pi);
+            h.finalize();
 
             assert.isTrue(
                 h.typeFulfillsType(gi1, gi2),
@@ -551,6 +560,7 @@ suite('Subtyping', function() {
                 'g', BoundsType.MORE_GENERAL_THAN, [t1i]);
             const gi2 = new GenericInstantiation(
                 'g', BoundsType.MORE_GENERAL_THAN, [t2i]);
+            h.finalize();
 
             assert.isFalse(
                 h.typeFulfillsType(gi1, gi2),
@@ -569,6 +579,7 @@ suite('Subtyping', function() {
             const gi2 = new GenericInstantiation(
                 'g', BoundsType.MORE_SPECIFIC_THAN, [pi]);
             td.addParent(pi);
+            h.finalize();
 
             assert.isTrue(
                 h.typeFulfillsType(gi1, gi2),
@@ -590,6 +601,7 @@ suite('Subtyping', function() {
                 'g', BoundsType.MORE_SPECIFIC_THAN, [p1i, p2i]);
             td.addParent(p1i);
             td.addParent(p2i);
+            h.finalize();
 
             assert.isTrue(
                 h.typeFulfillsType(gi1, gi2),
@@ -611,6 +623,7 @@ suite('Subtyping', function() {
                 'g', BoundsType.MORE_SPECIFIC_THAN, [pi]);
             t1d.addParent(pi);
             t2d.addParent(pi);
+            h.finalize();
 
             assert.isTrue(
                 h.typeFulfillsType(gi1, gi2),
@@ -631,6 +644,7 @@ suite('Subtyping', function() {
             const gi2 = new GenericInstantiation(
                 'g', BoundsType.MORE_SPECIFIC_THAN, [p1i, p2i]);
             td.addParent(p1i);
+            h.finalize();
 
             assert.isFalse(
                 h.typeFulfillsType(gi1, gi2),
@@ -651,6 +665,7 @@ suite('Subtyping', function() {
             const gi2 = new GenericInstantiation(
                 'g', BoundsType.MORE_SPECIFIC_THAN, [pi]);
             t1d.addParent(pi);
+            h.finalize();
 
             assert.isFalse(
                 h.typeFulfillsType(gi1, gi2),


### PR DESCRIPTION
### :clap: Resolves

<!-- The github issue this PR is for. If this PR closes the issue please
     put the word "Closes" before the issue -->
     
<!--Closes--> #issue-number
N/A
     
### :star2: Description

<!-- A description of what your PR does -->
Adds support for constraining generics on either their lower or upper bounds. There can be multiple bounds which are "anded" together, but they must be of the same bounds type (ie lower or upper).

### :bug: Testing

<!-- A list of steps you used for testing, or a list of unit tests you added. -->
Unit tests to define the behavior of boundded generics.

### :thought_balloon: Other info

<!-- Links to other relevant issues, pull requests, or information -->
N/A