### PR TITLE
feat: Add support for handling constrained generics in NCA and NCD

### DIFF
--- a/test/nearest_common_ancestors.mocha.js
+++ b/test/nearest_common_ancestors.mocha.js
@@ -22,10 +22,6 @@ suite('Nearest common ancestors', function() {
    */
   function assertNearestCommonAncestors(h, ts, eas, msg) {
     const aas = h.getNearestCommonAncestors(...ts);
-    // console.log(aas[0]);
-    // console.log(eas[0]);
-    // console.log(aas, aas[0].lowerBounds, aas[0].upperBounds);
-    // console.log(eas, eas[0].lowerBounds, eas[0].upperBounds);
     assert.equal(aas.length, eas.length, msg);
     assert.isTrue(aas.every((aa, i) => aa.equals(eas[i])), msg);
   }

--- a/test/nearest_common_ancestors.mocha.js
+++ b/test/nearest_common_ancestors.mocha.js
@@ -22,6 +22,10 @@ suite('Nearest common ancestors', function() {
    */
   function assertNearestCommonAncestors(h, ts, eas, msg) {
     const aas = h.getNearestCommonAncestors(...ts);
+    // console.log(aas[0]);
+    // console.log(eas[0]);
+    // console.log(aas, aas[0].lowerBounds, aas[0].upperBounds);
+    // console.log(eas, eas[0].lowerBounds, eas[0].upperBounds);
     assert.equal(aas.length, eas.length, msg);
     assert.isTrue(aas.every((aa, i) => aa.equals(eas[i])), msg);
   }
@@ -509,8 +513,9 @@ suite('Nearest common ancestors', function() {
             const ug = new GenericInstantiation('g', [], [t]);
             h.finalize();
 
+            const eg = new GenericInstantiation('', [], [t]);
             assertNearestCommonAncestors(
-                h, [g, ug], [ug],
+                h, [g, ug], [eg],
                 'Expected the nca of a generic and an upper bound generic to be the upper bound generic');
           });
 
@@ -523,8 +528,9 @@ suite('Nearest common ancestors', function() {
             const lg = new GenericInstantiation('g', [t]);
             h.finalize();
 
+            const eg = new GenericInstantiation('', [t]);
             assertNearestCommonAncestors(
-                h, [g, lg], [lg],
+                h, [g, lg], [eg],
                 'Expected the nca of a generic and a lower bound generic to be the lower bound generic');
           });
     });
@@ -541,8 +547,9 @@ suite('Nearest common ancestors', function() {
             cd.addParent(ti);
             h.finalize();
 
+            const eg = new GenericInstantiation('', [], [ti]);
             assertNearestCommonAncestors(
-                h, [ci, ug], [ug],
+                h, [ci, ug], [eg],
                 'Expected the nca of an upper bound generic and a subtype to be the upper bound generic');
           });
 
@@ -557,7 +564,7 @@ suite('Nearest common ancestors', function() {
             td.addParent(pi);
             h.finalize();
 
-            const eg = new GenericInstantiation('g', [], [pi]);
+            const eg = new GenericInstantiation('', [], [pi]);
             assertNearestCommonAncestors(
                 h, [pi, ug], [eg],
                 'Expected the nca of an upper bound generic and a supertype to be an upper bound generic with the supertype');
@@ -577,7 +584,7 @@ suite('Nearest common ancestors', function() {
             bd.addParent(pi);
             h.finalize();
 
-            const eg = new GenericInstantiation('g', [], [pi]);
+            const eg = new GenericInstantiation('', [], [pi]);
             assertNearestCommonAncestors(
                 h, [bi, ug], [eg],
                 'Expected the nca of an upper bound generic and a sibling to be an upper bound generic with the parent');
@@ -608,8 +615,9 @@ suite('Nearest common ancestors', function() {
             cd.addParent(ti);
             h.finalize();
 
+            const eg = new GenericInstantiation('', [ti]);
             assertNearestCommonAncestors(
-                h, [ci, lg], [lg],
+                h, [ci, lg], [eg],
                 'Expected the nca of a lower bound generic and a subtype to be the lower bound generic');
           });
 
@@ -624,7 +632,7 @@ suite('Nearest common ancestors', function() {
             td.addParent(pi);
             h.finalize();
 
-            const eg = new GenericInstantiation('g', [pi]);
+            const eg = new GenericInstantiation('', [pi]);
             assertNearestCommonAncestors(
                 h, [pi, lg], [eg],
                 'Expected the nca of lower bound generic and a supertype to be a lower bound generic with the supertype');
@@ -644,7 +652,7 @@ suite('Nearest common ancestors', function() {
             bd.addParent(pi);
             h.finalize();
 
-            const eg = new GenericInstantiation('g', [pi]);
+            const eg = new GenericInstantiation('', [pi]);
             assertNearestCommonAncestors(
                 h, [bi, lg], [eg],
                 'Expected the nca of a lower bound generic and a sibling to be a lower bound generic with the parent');
@@ -679,7 +687,7 @@ suite('Nearest common ancestors', function() {
             cd.addParent(ti);
             h.finalize();
 
-            const eg = new GenericInstantiation('g', [ti], [pi]);
+            const eg = new GenericInstantiation('', [ti], [pi]);
             assertNearestCommonAncestors(
                 h, [lg, ti, ug], [eg],
                 'Expected the nca of a lower bound generic, a middling type, and an upper bound generic to be a constrained generic with a lower bound of the middling type and an upper bound of the upper type');
@@ -699,8 +707,9 @@ suite('Nearest common ancestors', function() {
             cd.addParent(ti);
             h.finalize();
 
+            const eg = new GenericInstantiation('', [], [ti]);
             assertNearestCommonAncestors(
-                h, [tg, cg], [cg],
+                h, [tg, cg], [eg],
                 'Expected the nca of an upper bound generic and an upper bound generic with a subtype to be the first generic');
           });
 
@@ -716,8 +725,9 @@ suite('Nearest common ancestors', function() {
             td.addParent(pi);
             h.finalize();
 
+            const eg = new GenericInstantiation('', [], [pi]);
             assertNearestCommonAncestors(
-                h, [tg, pg], [pg],
+                h, [tg, pg], [eg],
                 'Expected the nca of an upper bound generic and an upper bound generic with a supertype to be the second upper bound generic');
           });
 
@@ -736,7 +746,7 @@ suite('Nearest common ancestors', function() {
             bd.addParent(pi);
             h.finalize();
 
-            const eg = new GenericInstantiation('g', [], [pi]);
+            const eg = new GenericInstantiation('', [], [pi]);
             assertNearestCommonAncestors(
                 h, [ag, bg], [eg],
                 'Expected the nca of an upper bound generic and an upper bound generic with a sibling sibling to be an upper bound generic with the parent');
@@ -770,8 +780,9 @@ suite('Nearest common ancestors', function() {
             cd.addParent(ti);
             h.finalize();
 
+            const eg = new GenericInstantiation('', [ti]);
             assertNearestCommonAncestors(
-                h, [tg, cg], [tg],
+                h, [tg, cg], [eg],
                 'Expected the nca of a lower bound generic and a lower bound generic with a subtype to be the first genneric');
           });
 
@@ -787,8 +798,9 @@ suite('Nearest common ancestors', function() {
             td.addParent(pi);
             h.finalize();
 
+            const eg = new GenericInstantiation('', [pi]);
             assertNearestCommonAncestors(
-                h, [tg, pg], [pg],
+                h, [tg, pg], [eg],
                 'Expected the nca of lower bound generic and a generic with a supertype to be the second lower bound generic');
           });
 
@@ -807,7 +819,7 @@ suite('Nearest common ancestors', function() {
             bd.addParent(pi);
             h.finalize();
 
-            const eg = new GenericInstantiation('g', [pi]);
+            const eg = new GenericInstantiation('', [pi]);
             assertNearestCommonAncestors(
                 h, [ag, bg], [eg],
                 'Expected the nca of a lower bound generic and lower bound generic with a sibling to be a lower bound generic with the parent');
@@ -844,7 +856,7 @@ suite('Nearest common ancestors', function() {
             cd.addParent(ti);
             h.finalize();
 
-            const eg = new GenericInstantiation('g', [ci], [pi]);
+            const eg = new GenericInstantiation('', [ci], [pi]);
             assertNearestCommonAncestors(
                 h, [lg, ug], [eg],
                 'Expected the nca of an upper bound generic and a lower bound generic to be a generic with both bounds');
@@ -866,7 +878,7 @@ suite('Nearest common ancestors', function() {
             cd.addParent(ti);
             h.finalize();
 
-            const eg = new GenericInstantiation('g', [ti], [pi]);
+            const eg = new GenericInstantiation('', [ti], [pi]);
             assertNearestCommonAncestors(
                 h, [lg, mg, ug], [eg],
                 'Expected the nca of a lower bound generic, a middling lower bound type, and an upper bound generic to be a constrained generic with a lower bound of the middling type and an upper bound of the upper type');
@@ -888,7 +900,7 @@ suite('Nearest common ancestors', function() {
             cd.addParent(ti);
             h.finalize();
 
-            const eg = new GenericInstantiation('g', [ci], [pi]);
+            const eg = new GenericInstantiation('', [ci], [pi]);
             assertNearestCommonAncestors(
                 h, [lg, mg, ug], [eg],
                 'Expected the nca of a lower bound generic, a middling upper bound type, and an upper bound generic to be a constrained generic with a lower bound of the lower type and an upper bound of the upper type');

--- a/test/nearest_common_ancestors.mocha.js
+++ b/test/nearest_common_ancestors.mocha.js
@@ -905,6 +905,89 @@ suite('Nearest common ancestors', function() {
                 h, [lg, mg, ug], [eg],
                 'Expected the nca of a lower bound generic, a middling upper bound type, and an upper bound generic to be a constrained generic with a lower bound of the lower type and an upper bound of the upper type');
           });
+
+      test('upper bounds which unify to multiple types result in multiple upper bound types', function() {
+        const h = new TypeHierarchy();
+        h.addTypeDef('a');
+        h.addTypeDef('b');
+        const cd = h.addTypeDef('c');
+        const dd = h.addTypeDef('d');
+        const ai = new ExplicitInstantiation('a');
+        const bi = new ExplicitInstantiation('b');
+        const ci = new ExplicitInstantiation('c');
+        const di = new ExplicitInstantiation('d');
+        cd.addParent(ai);
+        cd.addParent(bi);
+        dd.addParent(ai);
+        dd.addParent(bi);
+        const cg = new GenericInstantiation('g', [], [ci]);
+        const dg = new GenericInstantiation('g', [], [di]);
+        h.finalize();
+
+        const egs = [
+          new GenericInstantiation('', [], [ai]),
+          new GenericInstantiation('', [], [bi]),
+        ];
+        assertNearestCommonAncestors(
+            h, [cg, dg], egs,
+            'Expected that when upper bounds unify to multiple types it results in multiple upper bound types');
+      });
+
+      test('lower bounds which unify to multiple types result in multiple lower bound types', function() {
+        const h = new TypeHierarchy();
+        h.addTypeDef('a');
+        h.addTypeDef('b');
+        const cd = h.addTypeDef('c');
+        const dd = h.addTypeDef('d');
+        const ai = new ExplicitInstantiation('a');
+        const bi = new ExplicitInstantiation('b');
+        const ci = new ExplicitInstantiation('c');
+        const di = new ExplicitInstantiation('d');
+        cd.addParent(ai);
+        cd.addParent(bi);
+        dd.addParent(ai);
+        dd.addParent(bi);
+        const cg = new GenericInstantiation('g', [ci]);
+        const dg = new GenericInstantiation('g', [di]);
+        h.finalize();
+
+        const egs = [
+          new GenericInstantiation('', [ai]),
+          new GenericInstantiation('', [bi]),
+        ];
+        assertNearestCommonAncestors(
+            h, [cg, dg], egs,
+            'Expected that when lower bounds unify to multiple types it results in multiple lower bound types');
+      });
+
+      test('upper and lower bounds which unify to multiple types result in multiple upper and lower bound types', function() {
+        const h = new TypeHierarchy();
+        h.addTypeDef('a');
+        h.addTypeDef('b');
+        const cd = h.addTypeDef('c');
+        const dd = h.addTypeDef('d');
+        const ai = new ExplicitInstantiation('a');
+        const bi = new ExplicitInstantiation('b');
+        const ci = new ExplicitInstantiation('c');
+        const di = new ExplicitInstantiation('d');
+        cd.addParent(ai);
+        cd.addParent(bi);
+        dd.addParent(ai);
+        dd.addParent(bi);
+        const cg = new GenericInstantiation('g', [ci], [ci]);
+        const dg = new GenericInstantiation('g', [di], [di]);
+        h.finalize();
+
+        const egs = [
+          new GenericInstantiation('', [ai], [ai]),
+          new GenericInstantiation('', [ai], [bi]),
+          new GenericInstantiation('', [bi], [ai]),
+          new GenericInstantiation('', [bi], [bi]),
+        ];
+        assertNearestCommonAncestors(
+            h, [cg, dg], egs,
+            'Expected that when upper and lower bounds unify to multiple types it results in multiple upper and lower bound types');
+      });
     });
   });
 });

--- a/test/nearest_common_ancestors.mocha.js
+++ b/test/nearest_common_ancestors.mocha.js
@@ -5,7 +5,7 @@
  */
 
 import {TypeHierarchy} from '../src/type_hierarchy';
-import {BoundsType, ExplicitInstantiation, GenericInstantiation} from '../src/type_instantiation';
+import {ExplicitInstantiation, GenericInstantiation} from '../src/type_instantiation';
 import {assert} from 'chai';
 import {IncompatibleType, NotFinalized} from '../src/exceptions';
 
@@ -495,6 +495,404 @@ suite('Nearest common ancestors', function() {
       assertNearestCommonAncestors(
           h, [ti, g1i, pi, g2i], [pi],
           'Expected generics to be ignored when included with explicits');
+    });
+  });
+
+  suite('constrained generic nearest common ancestors', function() {
+    suite('constrained generics with unconstrained generics', function() {
+      test('nca of a generic and an upper bound generic is the upper bound generic',
+          function() {
+            const h = new TypeHierarchy();
+            h.addTypeDef('t');
+            const t = new ExplicitInstantiation('t');
+            const g = new GenericInstantiation('g');
+            const ug = new GenericInstantiation('g', [], [t]);
+            h.finalize();
+
+            assertNearestCommonAncestors(
+                h, [g, ug], [ug],
+                'Expected the nca of a generic and an upper bound generic to be the upper bound generic');
+          });
+
+      test('nca of a generic and a lower bound generic is the lower bound generic',
+          function() {
+            const h = new TypeHierarchy();
+            h.addTypeDef('t');
+            const t = new ExplicitInstantiation('t');
+            const g = new GenericInstantiation('g');
+            const lg = new GenericInstantiation('g', [t]);
+            h.finalize();
+
+            assertNearestCommonAncestors(
+                h, [g, lg], [lg],
+                'Expected the nca of a generic and a lower bound generic to be the lower bound generic');
+          });
+    });
+
+    suite('constrained generics with explicit types', function() {
+      test('nca of an upper bound generic and a subtype is the upper bound generic',
+          function() {
+            const h = new TypeHierarchy();
+            h.addTypeDef('t');
+            const cd = h.addTypeDef('c');
+            const ti = new ExplicitInstantiation('t');
+            const ci = new ExplicitInstantiation('c');
+            const ug = new GenericInstantiation('g', [], [ti]);
+            cd.addParent(ti);
+            h.finalize();
+
+            assertNearestCommonAncestors(
+                h, [ci, ug], [ug],
+                'Expected the nca of an upper bound generic and a subtype to be the upper bound generic');
+          });
+
+      test('nca of an upper bound generic and a supertype is an upper bound generic with the supertype',
+          function() {
+            const h = new TypeHierarchy();
+            h.addTypeDef('p');
+            const td = h.addTypeDef('t');
+            const ti = new ExplicitInstantiation('t');
+            const pi = new ExplicitInstantiation('p');
+            const ug = new GenericInstantiation('g', [], [ti]);
+            td.addParent(pi);
+            h.finalize();
+
+            const eg = new GenericInstantiation('g', [], [pi]);
+            assertNearestCommonAncestors(
+                h, [pi, ug], [eg],
+                'Expected the nca of an upper bound generic and a supertype to be an upper bound generic with the supertype');
+          });
+
+      test('nca of an upper bound generic and a sibling is an upper bound generic with the parent',
+          function() {
+            const h = new TypeHierarchy();
+            h.addTypeDef('p');
+            const ad = h.addTypeDef('a');
+            const bd = h.addTypeDef('b');
+            const ai = new ExplicitInstantiation('a');
+            const bi = new ExplicitInstantiation('b');
+            const pi = new ExplicitInstantiation('p');
+            const ug = new GenericInstantiation('g', [], [ai]);
+            ad.addParent(pi);
+            bd.addParent(pi);
+            h.finalize();
+
+            const eg = new GenericInstantiation('g', [], [pi]);
+            assertNearestCommonAncestors(
+                h, [bi, ug], [eg],
+                'Expected the nca of an upper bound generic and a sibling to be an upper bound generic with the parent');
+          });
+
+      test('upper bound generics and unrelated types do not unify', function() {
+        const h = new TypeHierarchy();
+        h.addTypeDef('t');
+        h.addTypeDef('u');
+        const ti = new ExplicitInstantiation('t');
+        const ui = new ExplicitInstantiation('u');
+        const g = new GenericInstantiation('g', [], [ti]);
+        h.finalize();
+
+        assertNearestCommonAncestors(
+            h, [ui, g], [],
+            'Expected an upper bound generic and an unrelated type to not unify');
+      });
+
+      test('nca of a lower bound generic and a subtype is the lower bound generic',
+          function() {
+            const h = new TypeHierarchy();
+            h.addTypeDef('t');
+            const cd = h.addTypeDef('c');
+            const ti = new ExplicitInstantiation('t');
+            const ci = new ExplicitInstantiation('c');
+            const lg = new GenericInstantiation('g', [ti]);
+            cd.addParent(ti);
+            h.finalize();
+
+            assertNearestCommonAncestors(
+                h, [ci, lg], [lg],
+                'Expected the nca of a lower bound generic and a subtype to be the lower bound generic');
+          });
+
+      test('nca of a lower bound generic and a supertype is a lower bound generic with the supertype',
+          function() {
+            const h = new TypeHierarchy();
+            h.addTypeDef('p');
+            const td = h.addTypeDef('t');
+            const ti = new ExplicitInstantiation('t');
+            const pi = new ExplicitInstantiation('p');
+            const lg = new GenericInstantiation('g', [ti]);
+            td.addParent(pi);
+            h.finalize();
+
+            const eg = new GenericInstantiation('g', [pi]);
+            assertNearestCommonAncestors(
+                h, [pi, lg], [eg],
+                'Expected the nca of lower bound generic and a supertype to be a lower bound generic with the supertype');
+          });
+
+      test('nca of a lower bound generic and a sibling is a lower bound generic with the parent',
+          function() {
+            const h = new TypeHierarchy();
+            h.addTypeDef('p');
+            const ad = h.addTypeDef('a');
+            const bd = h.addTypeDef('b');
+            const ai = new ExplicitInstantiation('a');
+            const bi = new ExplicitInstantiation('b');
+            const pi = new ExplicitInstantiation('p');
+            const lg = new GenericInstantiation('g', [ai]);
+            ad.addParent(pi);
+            bd.addParent(pi);
+            h.finalize();
+
+            const eg = new GenericInstantiation('g', [pi]);
+            assertNearestCommonAncestors(
+                h, [bi, lg], [eg],
+                'Expected the nca of a lower bound generic and a sibling to be a lower bound generic with the parent');
+          });
+
+      test('lower bound generics and unrelated types do not unify', function() {
+        const h = new TypeHierarchy();
+        h.addTypeDef('t');
+        h.addTypeDef('u');
+        const ti = new ExplicitInstantiation('t');
+        const ui = new ExplicitInstantiation('u');
+        const g = new GenericInstantiation('g', [ti]);
+        h.finalize();
+
+        assertNearestCommonAncestors(
+            h, [ui, g], [],
+            'Expected lower bound generic and an unrelated type to not unify');
+      });
+
+      test('nca of a lower bound generic, a middling type, and an upper bound generic is a constrained generic with a lower bound of the middling type, and an upper bound of the upper type',
+          function() {
+            const h = new TypeHierarchy();
+            h.addTypeDef('p');
+            const td = h.addTypeDef('t');
+            const cd = h.addTypeDef('c');
+            const pi = new ExplicitInstantiation('p');
+            const ti = new ExplicitInstantiation('t');
+            const ci = new ExplicitInstantiation('c');
+            const lg = new GenericInstantiation('g', [ci]);
+            const ug = new GenericInstantiation('g', [], [pi]);
+            td.addParent(pi);
+            cd.addParent(ti);
+            h.finalize();
+
+            const eg = new GenericInstantiation('g', [ti], [pi]);
+            assertNearestCommonAncestors(
+                h, [lg, ti, ug], [eg],
+                'Expected the nca of a lower bound generic, a middling type, and an upper bound generic to be a constrained generic with a lower bound of the middling type and an upper bound of the upper type');
+          });
+    });
+
+    suite('constrained generics with constrained generics', function() {
+      test('nca of an upper bound generic and an upper bound generic with a subtype is the first upper bound generic',
+          function() {
+            const h = new TypeHierarchy();
+            h.addTypeDef('t');
+            const cd = h.addTypeDef('c');
+            const ti = new ExplicitInstantiation('t');
+            const ci = new ExplicitInstantiation('c');
+            const tg = new GenericInstantiation('g', [], [ti]);
+            const cg = new GenericInstantiation('g', [], [ci]);
+            cd.addParent(ti);
+            h.finalize();
+
+            assertNearestCommonAncestors(
+                h, [tg, cg], [cg],
+                'Expected the nca of an upper bound generic and an upper bound generic with a subtype to be the first generic');
+          });
+
+      test('nca of an upper bound generic and an upper bound generic with a supertype is the second upper bound generic',
+          function() {
+            const h = new TypeHierarchy();
+            h.addTypeDef('p');
+            const td = h.addTypeDef('t');
+            const ti = new ExplicitInstantiation('t');
+            const pi = new ExplicitInstantiation('p');
+            const tg = new GenericInstantiation('g', [], [ti]);
+            const pg = new GenericInstantiation('g', [], [pi]);
+            td.addParent(pi);
+            h.finalize();
+
+            assertNearestCommonAncestors(
+                h, [tg, pg], [pg],
+                'Expected the nca of an upper bound generic and an upper bound generic with a supertype to be the second upper bound generic');
+          });
+
+      test('nca of an upper bound generic and an upper bound generic with a sibling is an upper bound generic with the parent',
+          function() {
+            const h = new TypeHierarchy();
+            h.addTypeDef('p');
+            const ad = h.addTypeDef('a');
+            const bd = h.addTypeDef('b');
+            const ai = new ExplicitInstantiation('a');
+            const bi = new ExplicitInstantiation('b');
+            const pi = new ExplicitInstantiation('p');
+            const ag = new GenericInstantiation('g', [], [ai]);
+            const bg = new GenericInstantiation('g', [], [bi]);
+            ad.addParent(pi);
+            bd.addParent(pi);
+            h.finalize();
+
+            const eg = new GenericInstantiation('g', [], [pi]);
+            assertNearestCommonAncestors(
+                h, [ag, bg], [eg],
+                'Expected the nca of an upper bound generic and an upper bound generic with a sibling sibling to be an upper bound generic with the parent');
+          });
+
+      test('upper bound generics and upper bound generics with unrelated types do not unify',
+          function() {
+            const h = new TypeHierarchy();
+            h.addTypeDef('t');
+            h.addTypeDef('u');
+            const ti = new ExplicitInstantiation('t');
+            const ui = new ExplicitInstantiation('u');
+            const ug = new GenericInstantiation('g', [], [ui]);
+            const tg = new GenericInstantiation('g', [], [ti]);
+            h.finalize();
+
+            assertNearestCommonAncestors(
+                h, [ug, tg], [],
+                'Expected an upper bound generic and an upper bound generic with an unrelated type to not unify');
+          });
+
+      test('nca of a lower bound generic and a lower bound generic with a subtype is the first lower bound generic',
+          function() {
+            const h = new TypeHierarchy();
+            h.addTypeDef('t');
+            const cd = h.addTypeDef('c');
+            const ti = new ExplicitInstantiation('t');
+            const ci = new ExplicitInstantiation('c');
+            const tg = new GenericInstantiation('g', [ti]);
+            const cg = new GenericInstantiation('g', [ci]);
+            cd.addParent(ti);
+            h.finalize();
+
+            assertNearestCommonAncestors(
+                h, [tg, cg], [tg],
+                'Expected the nca of a lower bound generic and a lower bound generic with a subtype to be the first genneric');
+          });
+
+      test('nca of a lower bound generic and a lower bound generic with a supertype is the second lower bound generic',
+          function() {
+            const h = new TypeHierarchy();
+            h.addTypeDef('p');
+            const td = h.addTypeDef('t');
+            const ti = new ExplicitInstantiation('t');
+            const pi = new ExplicitInstantiation('p');
+            const tg = new GenericInstantiation('g', [ti]);
+            const pg = new GenericInstantiation('g', [pi]);
+            td.addParent(pi);
+            h.finalize();
+
+            assertNearestCommonAncestors(
+                h, [tg, pg], [pg],
+                'Expected the nca of lower bound generic and a generic with a supertype to be the second lower bound generic');
+          });
+
+      test('nca of a lower bound generic and a lower bound generic with a sibling is a lower bound generic with the parent',
+          function() {
+            const h = new TypeHierarchy();
+            h.addTypeDef('p');
+            const ad = h.addTypeDef('a');
+            const bd = h.addTypeDef('b');
+            const ai = new ExplicitInstantiation('a');
+            const bi = new ExplicitInstantiation('b');
+            const pi = new ExplicitInstantiation('p');
+            const ag = new GenericInstantiation('g', [ai]);
+            const bg = new GenericInstantiation('g', [bi]);
+            ad.addParent(pi);
+            bd.addParent(pi);
+            h.finalize();
+
+            const eg = new GenericInstantiation('g', [pi]);
+            assertNearestCommonAncestors(
+                h, [ag, bg], [eg],
+                'Expected the nca of a lower bound generic and lower bound generic with a sibling to be a lower bound generic with the parent');
+          });
+
+      test('lower bound generics and lower bound generics unrelated types do not unify',
+          function() {
+            const h = new TypeHierarchy();
+            h.addTypeDef('t');
+            h.addTypeDef('u');
+            const ti = new ExplicitInstantiation('t');
+            const ui = new ExplicitInstantiation('u');
+            const ug = new GenericInstantiation('g', [ui]);
+            const tg = new GenericInstantiation('g', [ti]);
+            h.finalize();
+
+            assertNearestCommonAncestors(
+                h, [ug, tg], [],
+                'Expected lower bound generic and a lower bound generic with an unrelated type to not unify');
+          });
+
+      test('nca of an upper bound generic and a lower bound generic is a generic with both bounds',
+          function() {
+            const h = new TypeHierarchy();
+            h.addTypeDef('p');
+            const td = h.addTypeDef('t');
+            const cd = h.addTypeDef('c');
+            const pi = new ExplicitInstantiation('p');
+            const ti = new ExplicitInstantiation('t');
+            const ci = new ExplicitInstantiation('c');
+            const lg = new GenericInstantiation('g', [ci]);
+            const ug = new GenericInstantiation('g', [], [pi]);
+            td.addParent(pi);
+            cd.addParent(ti);
+            h.finalize();
+
+            const eg = new GenericInstantiation('g', [ci], [pi]);
+            assertNearestCommonAncestors(
+                h, [lg, ug], [eg],
+                'Expected the nca of an upper bound generic and a lower bound generic to be a generic with both bounds');
+          });
+
+      test('nca of a lower bound generic, and middling lower bound type, and an upper bound generic is a constrained generic with a lower bound of the middling type and an upper bound of the upper type',
+          function() {
+            const h = new TypeHierarchy();
+            h.addTypeDef('p');
+            const td = h.addTypeDef('t');
+            const cd = h.addTypeDef('c');
+            const pi = new ExplicitInstantiation('p');
+            const ti = new ExplicitInstantiation('t');
+            const ci = new ExplicitInstantiation('c');
+            const lg = new GenericInstantiation('g', [ci]);
+            const mg = new GenericInstantiation('g', [ti]);
+            const ug = new GenericInstantiation('g', [], [pi]);
+            td.addParent(pi);
+            cd.addParent(ti);
+            h.finalize();
+
+            const eg = new GenericInstantiation('g', [ti], [pi]);
+            assertNearestCommonAncestors(
+                h, [lg, mg, ug], [eg],
+                'Expected the nca of a lower bound generic, a middling lower bound type, and an upper bound generic to be a constrained generic with a lower bound of the middling type and an upper bound of the upper type');
+          });
+
+      test('nca of a lower bound generic, a middling upper bound type, and an upper bound generic is a constrained generic with a lower bound of the lower type, and an upper bound of the upper type',
+          function() {
+            const h = new TypeHierarchy();
+            h.addTypeDef('p');
+            const td = h.addTypeDef('t');
+            const cd = h.addTypeDef('c');
+            const pi = new ExplicitInstantiation('p');
+            const ti = new ExplicitInstantiation('t');
+            const ci = new ExplicitInstantiation('c');
+            const lg = new GenericInstantiation('g', [ci]);
+            const mg = new GenericInstantiation('g', [], [ti]);
+            const ug = new GenericInstantiation('g', [], [pi]);
+            td.addParent(pi);
+            cd.addParent(ti);
+            h.finalize();
+
+            const eg = new GenericInstantiation('g', [ci], [pi]);
+            assertNearestCommonAncestors(
+                h, [lg, mg, ug], [eg],
+                'Expected the nca of a lower bound generic, a middling upper bound type, and an upper bound generic to be a constrained generic with a lower bound of the lower type and an upper bound of the upper type');
+          });
     });
   });
 });

--- a/test/nearest_common_descendants.mocha.js
+++ b/test/nearest_common_descendants.mocha.js
@@ -5,7 +5,7 @@
  */
 
 import {TypeHierarchy} from '../src/type_hierarchy';
-import {BoundsType, ExplicitInstantiation, GenericInstantiation} from '../src/type_instantiation';
+import {ExplicitInstantiation, GenericInstantiation} from '../src/type_instantiation';
 import {assert} from 'chai';
 import {IncompatibleType, NotFinalized} from '../src/exceptions';
 
@@ -490,6 +490,404 @@ suite('Nearest common descendants', function() {
       assertNearestCommonDescendants(
           h, [ti, ci, gi], [ci],
           'Expected generics to be ignored when included with explicits');
+    });
+  });
+
+  suite('constrained generic nearest common descendants', function() {
+    suite('constrained generics with unconstrained generics', function() {
+      test('ncd of a generic and an upper bound generic is the upper bound generic',
+          function() {
+            const h = new TypeHierarchy();
+            h.addTypeDef('t');
+            const t = new ExplicitInstantiation('t');
+            const g = new GenericInstantiation('g');
+            const ug = new GenericInstantiation('g', [], [t]);
+            h.finalize();
+
+            assertNearestCommonDescendants(
+                h, [g, ug], [ug],
+                'Expected the ncd of a generic and an upper bound generic to be the upper bound generic');
+          });
+
+      test('ncd of a generic and a lower bound generic is the lower bound generic',
+          function() {
+            const h = new TypeHierarchy();
+            h.addTypeDef('t');
+            const t = new ExplicitInstantiation('t');
+            const g = new GenericInstantiation('g');
+            const lg = new GenericInstantiation('g', [t]);
+            h.finalize();
+
+            assertNearestCommonDescendants(
+                h, [g, lg], [lg],
+                'Expected the ncd of a generic and a lower bound generic to be the lower bound generic');
+          });
+    });
+
+    suite('constrained generics with explicit types', function() {
+      test('ncd of an upper bound generic and a subtype is an upper bound generic with the subtype',
+          function() {
+            const h = new TypeHierarchy();
+            h.addTypeDef('t');
+            const cd = h.addTypeDef('c');
+            const ti = new ExplicitInstantiation('t');
+            const ci = new ExplicitInstantiation('c');
+            const ug = new GenericInstantiation('g', [], [ti]);
+            cd.addParent(ti);
+            h.finalize();
+
+            const ed = new GenericInstantiation('g', [], [ci]);
+            assertNearestCommonDescendants(
+                h, [ci, ug], [ed],
+                'Expected the ncd of an upper bound generic and a subtype to be an upper bound generic with the subtype');
+          });
+
+      test('ncd of an upper bound generic and a supertype is the upper bound generic',
+          function() {
+            const h = new TypeHierarchy();
+            h.addTypeDef('p');
+            const td = h.addTypeDef('t');
+            const ti = new ExplicitInstantiation('t');
+            const pi = new ExplicitInstantiation('p');
+            const ug = new GenericInstantiation('g', [], [ti]);
+            td.addParent(pi);
+            h.finalize();
+
+            assertNearestCommonDescendants(
+                h, [pi, ug], [ug],
+                'Expected the ncd of an upper bound generic and a supertype to be the upper bound generic');
+          });
+
+      test('ncd of an upper bound generic and a coparent is an upper bound generic with the child',
+          function() {
+            const h = new TypeHierarchy();
+            h.addTypeDef('a');
+            h.addTypeDef('b');
+            const cd = h.addTypeDef('c');
+            const ai = new ExplicitInstantiation('a');
+            const bi = new ExplicitInstantiation('b');
+            const ci = new ExplicitInstantiation('c');
+            const ug = new GenericInstantiation('g', [], [ai]);
+            cd.addParent(ai);
+            cd.addParent(bi);
+            h.finalize();
+
+            const eg = new GenericInstantiation('g', [], [ci]);
+            assertNearestCommonDescendants(
+                h, [bi, ug], [eg],
+                'Expected the ncd of an upper bound generic and a coparent to be an upper bound generic with the child');
+          });
+
+      test('upper bound generics and unrelated types do not unify', function() {
+        const h = new TypeHierarchy();
+        h.addTypeDef('t');
+        h.addTypeDef('u');
+        const ti = new ExplicitInstantiation('t');
+        const ui = new ExplicitInstantiation('u');
+        const g = new GenericInstantiation('g', [], [ti]);
+        h.finalize();
+
+        assertNearestCommonDescendants(
+            h, [ui, g], [],
+            'Expected an upper bound generic and an unrelated type to not unify');
+      });
+
+      test('ncd of a lower bound generic and a subtype is a lower bound generic with the subtype',
+          function() {
+            const h = new TypeHierarchy();
+            h.addTypeDef('t');
+            const cd = h.addTypeDef('c');
+            const ti = new ExplicitInstantiation('t');
+            const ci = new ExplicitInstantiation('c');
+            const lg = new GenericInstantiation('g', [ti]);
+            cd.addParent(ti);
+            h.finalize();
+
+            const ed = new GenericInstantiation('g', [ci]);
+            assertNearestCommonDescendants(
+                h, [ci, lg], [ed],
+                'Expected the ncd of a lower bound generic and a subtype to be a lower bound generic with the subtype');
+          });
+
+      test('ncd of a lower bound generic and a supertype is the lower bound generic',
+          function() {
+            const h = new TypeHierarchy();
+            h.addTypeDef('p');
+            const td = h.addTypeDef('t');
+            const ti = new ExplicitInstantiation('t');
+            const pi = new ExplicitInstantiation('p');
+            const lg = new GenericInstantiation('g', [ti]);
+            td.addParent(pi);
+            h.finalize();
+
+            assertNearestCommonDescendants(
+                h, [pi, lg], [lg],
+                'Expected the ncd of a lower bound generic and a supertype to be the lower bound generic');
+          });
+
+      test('ncd of a lower bound generic and a coparent is a lower bound generic with the child',
+          function() {
+            const h = new TypeHierarchy();
+            h.addTypeDef('a');
+            h.addTypeDef('b');
+            const cd = h.addTypeDef('c');
+            const ai = new ExplicitInstantiation('a');
+            const bi = new ExplicitInstantiation('b');
+            const ci = new ExplicitInstantiation('c');
+            const lg = new GenericInstantiation('g', [ai]);
+            cd.addParent(ai);
+            cd.addParent(bi);
+            h.finalize();
+
+            const eg = new GenericInstantiation('g', [ci]);
+            assertNearestCommonDescendants(
+                h, [bi, lg], [eg],
+                'Expected the ncd of a lower bound generic and a coparent to be a lower bound generic with the child');
+          });
+
+      test('lower bound generics and unrelated types do not unify', function() {
+        const h = new TypeHierarchy();
+        h.addTypeDef('t');
+        h.addTypeDef('u');
+        const ti = new ExplicitInstantiation('t');
+        const ui = new ExplicitInstantiation('u');
+        const g = new GenericInstantiation('g', [ti]);
+        h.finalize();
+
+        assertNearestCommonDescendants(
+            h, [ui, g], [],
+            'Expected lower bound generic and an unrelated type to not unify');
+      });
+
+      test('ncd of a lower bound generic, a middling type, and an upper bound generic is a constrained generic with a lower bound of the lower type and an upper bound of the middling type',
+          function() {
+            const h = new TypeHierarchy();
+            h.addTypeDef('p');
+            const td = h.addTypeDef('t');
+            const cd = h.addTypeDef('c');
+            const pi = new ExplicitInstantiation('p');
+            const ti = new ExplicitInstantiation('t');
+            const ci = new ExplicitInstantiation('c');
+            const lg = new GenericInstantiation('g', [ci]);
+            const ug = new GenericInstantiation('g', [], [pi]);
+            td.addParent(pi);
+            cd.addParent(ti);
+            h.finalize();
+
+            const eg = new GenericInstantiation('g', [ci], [ti]);
+            assertNearestCommonDescendants(
+                h, [lg, ti, ug], [eg],
+                'Expected the ncd of a lower bound generic, a middling type, and an upper bound generic to be a constrained generic with a lower bound of the lower type and an upper bound of the middling type');
+          });
+    });
+
+    suite('constrained generics with constrained generics', function() {
+      test('ncd of an upper bound generic and an upper bound generic with a subtype is the second upper bound generic',
+          function() {
+            const h = new TypeHierarchy();
+            h.addTypeDef('t');
+            const cd = h.addTypeDef('c');
+            const ti = new ExplicitInstantiation('t');
+            const ci = new ExplicitInstantiation('c');
+            const tg = new GenericInstantiation('g', [], [ti]);
+            const cg = new GenericInstantiation('g', [], [ci]);
+            cd.addParent(ti);
+            h.finalize();
+
+            assertNearestCommonDescendants(
+                h, [tg, cg], [cg],
+                'Expected the ncd of an upper bound generic and an upper bound generic with a subtype to be the second upper bound generic');
+          });
+
+      test('ncd of an upper bound generic and an upper bound generic with a supertype is the first upper bound generic',
+          function() {
+            const h = new TypeHierarchy();
+            h.addTypeDef('p');
+            const td = h.addTypeDef('t');
+            const ti = new ExplicitInstantiation('t');
+            const pi = new ExplicitInstantiation('p');
+            const tg = new GenericInstantiation('g', [], [ti]);
+            const pg = new GenericInstantiation('g', [], [pi]);
+            td.addParent(pi);
+            h.finalize();
+
+            assertNearestCommonDescendants(
+                h, [tg, pg], [tg],
+                'Expected the ncd of an upper bound generic and an upper bound generic with a supertype to be the first upper bound generic');
+          });
+
+      test('ncd of an upper bound generic and an upper bound generic with a coparent is an upper bound generic with the child',
+          function() {
+            const h = new TypeHierarchy();
+            h.addTypeDef('a');
+            h.addTypeDef('b');
+            const cd = h.addTypeDef('c');
+            const ai = new ExplicitInstantiation('a');
+            const bi = new ExplicitInstantiation('b');
+            const ci = new ExplicitInstantiation('c');
+            const ag = new GenericInstantiation('g', [], [ai]);
+            const bg = new GenericInstantiation('g', [], [bi]);
+            cd.addParent(ai);
+            cd.addParent(bi);
+            h.finalize();
+
+            const eg = new GenericInstantiation('g', [], [ci]);
+            assertNearestCommonDescendants(
+                h, [ag, bg], [eg],
+                'Expected the ncd of an upper bound generic and an upper bound generic with a comparent to be an upper bound generic with the child');
+          });
+
+      test('upper bound generics and upper bound generics with unrelated types do not unify',
+          function() {
+            const h = new TypeHierarchy();
+            h.addTypeDef('t');
+            h.addTypeDef('u');
+            const ti = new ExplicitInstantiation('t');
+            const ui = new ExplicitInstantiation('u');
+            const ug = new GenericInstantiation('g', [], [ui]);
+            const tg = new GenericInstantiation('g', [], [ti]);
+            h.finalize();
+
+            assertNearestCommonDescendants(
+                h, [ug, tg], [],
+                'Expected an upper bound generic and an upper bound generic with an unrelated type to not unify');
+          });
+
+      test('ncd of a lower bound generic and a lower bound generic with a subtype is the second lower bound type',
+          function() {
+            const h = new TypeHierarchy();
+            h.addTypeDef('t');
+            const cd = h.addTypeDef('c');
+            const ti = new ExplicitInstantiation('t');
+            const ci = new ExplicitInstantiation('c');
+            const tg = new GenericInstantiation('g', [ti]);
+            const cg = new GenericInstantiation('g', [ci]);
+            cd.addParent(ti);
+            h.finalize();
+
+            assertNearestCommonDescendants(
+                h, [tg, cg], [cg],
+                'Expected the ncd of a lower bound generic and a lower bound generic with a subtype to be the second lower bound generic');
+          });
+
+      test('ncd of a lower bound generic and a lower bound generic with a supertype is the first lower bound generic',
+          function() {
+            const h = new TypeHierarchy();
+            h.addTypeDef('p');
+            const td = h.addTypeDef('t');
+            const ti = new ExplicitInstantiation('t');
+            const pi = new ExplicitInstantiation('p');
+            const tg = new GenericInstantiation('g', [ti]);
+            const pg = new GenericInstantiation('g', [pi]);
+            td.addParent(pi);
+            h.finalize();
+
+            assertNearestCommonDescendants(
+                h, [tg, pg], [tg],
+                'Expected the ncd of a lower bound generic and lower bound generic with a supertype to be the first lower bound generic');
+          });
+
+      test('ncd of a lower bound generic and a lower bound generic with a coparent is a lower bound generic with the child',
+          function() {
+            const h = new TypeHierarchy();
+            h.addTypeDef('a');
+            h.addTypeDef('b');
+            const cd = h.addTypeDef('c');
+            const ai = new ExplicitInstantiation('a');
+            const bi = new ExplicitInstantiation('b');
+            const ci = new ExplicitInstantiation('c');
+            const ag = new GenericInstantiation('g', [ai]);
+            const bg = new GenericInstantiation('g', [bi]);
+            cd.addParent(ai);
+            cd.addParent(bi);
+            h.finalize();
+
+            const eg = new GenericInstantiation('g', [ci]);
+            assertNearestCommonDescendants(
+                h, [ag, bg], [eg],
+                'Expected the ncd of a lower bound generic and a lower bound generic witha comparent is a lower bound generic with teh child');
+          });
+
+      test('lower bound generics and lower bound generics unrelated types do not unify',
+          function() {
+            const h = new TypeHierarchy();
+            h.addTypeDef('t');
+            h.addTypeDef('u');
+            const ti = new ExplicitInstantiation('t');
+            const ui = new ExplicitInstantiation('u');
+            const ug = new GenericInstantiation('g', [ui]);
+            const tg = new GenericInstantiation('g', [ti]);
+            h.finalize();
+
+            assertNearestCommonDescendants(
+                h, [ug, tg], [],
+                'Expected lower bound generic and a lower bound generic with an unrelated type to not unify');
+          });
+
+      test('ncd of an upper bound generic and a lower bound generic is a generic with both bounds',
+          function() {
+            const h = new TypeHierarchy();
+            h.addTypeDef('p');
+            const td = h.addTypeDef('t');
+            const cd = h.addTypeDef('c');
+            const pi = new ExplicitInstantiation('p');
+            const ti = new ExplicitInstantiation('t');
+            const ci = new ExplicitInstantiation('c');
+            const lg = new GenericInstantiation('g', [ci]);
+            const ug = new GenericInstantiation('g', [], [pi]);
+            td.addParent(pi);
+            cd.addParent(ti);
+            h.finalize();
+
+            const eg = new GenericInstantiation('g', [ci], [pi]);
+            assertNearestCommonDescendants(
+                h, [lg, ug], [eg],
+                'Expected the ncd of an upper bound generic and a lower bound generic to be a generic with both bounds');
+          });
+
+      test('ncd of a lower bound generic, a middling lower bound type, and an upper bound generic is a constrained generic with a lower bound of the lower type and an upper bound of the upper type',
+          function() {
+            const h = new TypeHierarchy();
+            h.addTypeDef('p');
+            const td = h.addTypeDef('t');
+            const cd = h.addTypeDef('c');
+            const pi = new ExplicitInstantiation('p');
+            const ti = new ExplicitInstantiation('t');
+            const ci = new ExplicitInstantiation('c');
+            const lg = new GenericInstantiation('g', [ci]);
+            const mg = new GenericInstantiation('g', [ti]);
+            const ug = new GenericInstantiation('g', [], [pi]);
+            td.addParent(pi);
+            cd.addParent(ti);
+            h.finalize();
+
+            const eg = new GenericInstantiation('g', [ci], [pi]);
+            assertNearestCommonDescendants(
+                h, [lg, mg, ug], [eg],
+                'Expected the ncd of a lower bound generic, a middling lower bound type, and an upper bound generic is a constrained generic with a lower bound of the lower type and an upper bound of the upper type');
+          });
+
+      test('ncd of a lower bound generic, a middling upper bound type, and an upper bound generic is a constrained generic with a lower bound of the lower type and an upper bound of the middling type',
+          function() {
+            const h = new TypeHierarchy();
+            h.addTypeDef('p');
+            const td = h.addTypeDef('t');
+            const cd = h.addTypeDef('c');
+            const pi = new ExplicitInstantiation('p');
+            const ti = new ExplicitInstantiation('t');
+            const ci = new ExplicitInstantiation('c');
+            const lg = new GenericInstantiation('g', [ci]);
+            const mg = new GenericInstantiation('g', [], [ti]);
+            const ug = new GenericInstantiation('g', [], [pi]);
+            td.addParent(pi);
+            cd.addParent(ti);
+            h.finalize();
+
+            const eg = new GenericInstantiation('g', [ci], [ti]);
+            assertNearestCommonDescendants(
+                h, [lg, mg, ug], [eg],
+                'Expected the ncd of a lower bound generic, a middling upper bound type, and an upper bound generic to be a constrained generic with a lower bound of the lower type and an upper bound of the middling type');
+          });
     });
   });
 });

--- a/test/nearest_common_descendants.mocha.js
+++ b/test/nearest_common_descendants.mocha.js
@@ -22,6 +22,8 @@ suite('Nearest common descendants', function() {
    */
   function assertNearestCommonDescendants(h, ts, eds, msg) {
     const ads = h.getNearestCommonDescendants(...ts);
+    console.log(ads[0]);
+    console.log(eds[0]);
     assert.equal(ads.length, eds.length, msg);
     assert.isTrue(ads.every((ad, i) => ad.equals(eds[i])), msg);
   }
@@ -504,8 +506,9 @@ suite('Nearest common descendants', function() {
             const ug = new GenericInstantiation('g', [], [t]);
             h.finalize();
 
+            const eg = new GenericInstantiation('', [], [t]);
             assertNearestCommonDescendants(
-                h, [g, ug], [ug],
+                h, [g, ug], [eg],
                 'Expected the ncd of a generic and an upper bound generic to be the upper bound generic');
           });
 
@@ -518,8 +521,9 @@ suite('Nearest common descendants', function() {
             const lg = new GenericInstantiation('g', [t]);
             h.finalize();
 
+            const eg = new GenericInstantiation('', [t]);
             assertNearestCommonDescendants(
-                h, [g, lg], [lg],
+                h, [g, lg], [eg],
                 'Expected the ncd of a generic and a lower bound generic to be the lower bound generic');
           });
     });
@@ -536,7 +540,7 @@ suite('Nearest common descendants', function() {
             cd.addParent(ti);
             h.finalize();
 
-            const ed = new GenericInstantiation('g', [], [ci]);
+            const ed = new GenericInstantiation('', [], [ci]);
             assertNearestCommonDescendants(
                 h, [ci, ug], [ed],
                 'Expected the ncd of an upper bound generic and a subtype to be an upper bound generic with the subtype');
@@ -553,8 +557,9 @@ suite('Nearest common descendants', function() {
             td.addParent(pi);
             h.finalize();
 
+            const eg = new GenericInstantiation('', [], [ti]);
             assertNearestCommonDescendants(
-                h, [pi, ug], [ug],
+                h, [pi, ug], [eg],
                 'Expected the ncd of an upper bound generic and a supertype to be the upper bound generic');
           });
 
@@ -572,7 +577,7 @@ suite('Nearest common descendants', function() {
             cd.addParent(bi);
             h.finalize();
 
-            const eg = new GenericInstantiation('g', [], [ci]);
+            const eg = new GenericInstantiation('', [], [ci]);
             assertNearestCommonDescendants(
                 h, [bi, ug], [eg],
                 'Expected the ncd of an upper bound generic and a coparent to be an upper bound generic with the child');
@@ -603,7 +608,7 @@ suite('Nearest common descendants', function() {
             cd.addParent(ti);
             h.finalize();
 
-            const ed = new GenericInstantiation('g', [ci]);
+            const ed = new GenericInstantiation('', [ci]);
             assertNearestCommonDescendants(
                 h, [ci, lg], [ed],
                 'Expected the ncd of a lower bound generic and a subtype to be a lower bound generic with the subtype');
@@ -620,8 +625,9 @@ suite('Nearest common descendants', function() {
             td.addParent(pi);
             h.finalize();
 
+            const eg = new GenericInstantiation('', [ti]);
             assertNearestCommonDescendants(
-                h, [pi, lg], [lg],
+                h, [pi, lg], [eg],
                 'Expected the ncd of a lower bound generic and a supertype to be the lower bound generic');
           });
 
@@ -639,7 +645,7 @@ suite('Nearest common descendants', function() {
             cd.addParent(bi);
             h.finalize();
 
-            const eg = new GenericInstantiation('g', [ci]);
+            const eg = new GenericInstantiation('', [ci]);
             assertNearestCommonDescendants(
                 h, [bi, lg], [eg],
                 'Expected the ncd of a lower bound generic and a coparent to be a lower bound generic with the child');
@@ -674,7 +680,7 @@ suite('Nearest common descendants', function() {
             cd.addParent(ti);
             h.finalize();
 
-            const eg = new GenericInstantiation('g', [ci], [ti]);
+            const eg = new GenericInstantiation('', [ci], [ti]);
             assertNearestCommonDescendants(
                 h, [lg, ti, ug], [eg],
                 'Expected the ncd of a lower bound generic, a middling type, and an upper bound generic to be a constrained generic with a lower bound of the lower type and an upper bound of the middling type');
@@ -694,8 +700,9 @@ suite('Nearest common descendants', function() {
             cd.addParent(ti);
             h.finalize();
 
+            const eg = new GenericInstantiation('', [], [ci]);
             assertNearestCommonDescendants(
-                h, [tg, cg], [cg],
+                h, [tg, cg], [eg],
                 'Expected the ncd of an upper bound generic and an upper bound generic with a subtype to be the second upper bound generic');
           });
 
@@ -711,8 +718,9 @@ suite('Nearest common descendants', function() {
             td.addParent(pi);
             h.finalize();
 
+            const eg = new GenericInstantiation('', [], [ti]);
             assertNearestCommonDescendants(
-                h, [tg, pg], [tg],
+                h, [tg, pg], [eg],
                 'Expected the ncd of an upper bound generic and an upper bound generic with a supertype to be the first upper bound generic');
           });
 
@@ -731,7 +739,7 @@ suite('Nearest common descendants', function() {
             cd.addParent(bi);
             h.finalize();
 
-            const eg = new GenericInstantiation('g', [], [ci]);
+            const eg = new GenericInstantiation('', [], [ci]);
             assertNearestCommonDescendants(
                 h, [ag, bg], [eg],
                 'Expected the ncd of an upper bound generic and an upper bound generic with a comparent to be an upper bound generic with the child');
@@ -765,8 +773,9 @@ suite('Nearest common descendants', function() {
             cd.addParent(ti);
             h.finalize();
 
+            const eg = new GenericInstantiation('', [ci]);
             assertNearestCommonDescendants(
-                h, [tg, cg], [cg],
+                h, [tg, cg], [eg],
                 'Expected the ncd of a lower bound generic and a lower bound generic with a subtype to be the second lower bound generic');
           });
 
@@ -782,8 +791,9 @@ suite('Nearest common descendants', function() {
             td.addParent(pi);
             h.finalize();
 
+            const eg = new GenericInstantiation('', [ti]);
             assertNearestCommonDescendants(
-                h, [tg, pg], [tg],
+                h, [tg, pg], [eg],
                 'Expected the ncd of a lower bound generic and lower bound generic with a supertype to be the first lower bound generic');
           });
 
@@ -802,7 +812,7 @@ suite('Nearest common descendants', function() {
             cd.addParent(bi);
             h.finalize();
 
-            const eg = new GenericInstantiation('g', [ci]);
+            const eg = new GenericInstantiation('', [ci]);
             assertNearestCommonDescendants(
                 h, [ag, bg], [eg],
                 'Expected the ncd of a lower bound generic and a lower bound generic witha comparent is a lower bound generic with teh child');
@@ -839,7 +849,7 @@ suite('Nearest common descendants', function() {
             cd.addParent(ti);
             h.finalize();
 
-            const eg = new GenericInstantiation('g', [ci], [pi]);
+            const eg = new GenericInstantiation('', [ci], [pi]);
             assertNearestCommonDescendants(
                 h, [lg, ug], [eg],
                 'Expected the ncd of an upper bound generic and a lower bound generic to be a generic with both bounds');
@@ -861,7 +871,7 @@ suite('Nearest common descendants', function() {
             cd.addParent(ti);
             h.finalize();
 
-            const eg = new GenericInstantiation('g', [ci], [pi]);
+            const eg = new GenericInstantiation('', [ci], [pi]);
             assertNearestCommonDescendants(
                 h, [lg, mg, ug], [eg],
                 'Expected the ncd of a lower bound generic, a middling lower bound type, and an upper bound generic is a constrained generic with a lower bound of the lower type and an upper bound of the upper type');
@@ -883,7 +893,7 @@ suite('Nearest common descendants', function() {
             cd.addParent(ti);
             h.finalize();
 
-            const eg = new GenericInstantiation('g', [ci], [ti]);
+            const eg = new GenericInstantiation('', [ci], [ti]);
             assertNearestCommonDescendants(
                 h, [lg, mg, ug], [eg],
                 'Expected the ncd of a lower bound generic, a middling upper bound type, and an upper bound generic to be a constrained generic with a lower bound of the lower type and an upper bound of the middling type');

--- a/test/nearest_common_descendants.mocha.js
+++ b/test/nearest_common_descendants.mocha.js
@@ -22,8 +22,6 @@ suite('Nearest common descendants', function() {
    */
   function assertNearestCommonDescendants(h, ts, eds, msg) {
     const ads = h.getNearestCommonDescendants(...ts);
-    console.log(ads[0]);
-    console.log(eds[0]);
     assert.equal(ads.length, eds.length, msg);
     assert.isTrue(ads.every((ad, i) => ad.equals(eds[i])), msg);
   }

--- a/test/nearest_common_descendants.mocha.js
+++ b/test/nearest_common_descendants.mocha.js
@@ -898,6 +898,89 @@ suite('Nearest common descendants', function() {
                 h, [lg, mg, ug], [eg],
                 'Expected the ncd of a lower bound generic, a middling upper bound type, and an upper bound generic to be a constrained generic with a lower bound of the lower type and an upper bound of the middling type');
           });
+
+      test('upper bounds which unify to multiple types result in multiple upper bound types', function() {
+        const h = new TypeHierarchy();
+        h.addTypeDef('a');
+        h.addTypeDef('b');
+        const cd = h.addTypeDef('c');
+        const dd = h.addTypeDef('d');
+        const ai = new ExplicitInstantiation('a');
+        const bi = new ExplicitInstantiation('b');
+        const ci = new ExplicitInstantiation('c');
+        const di = new ExplicitInstantiation('d');
+        cd.addParent(ai);
+        cd.addParent(bi);
+        dd.addParent(ai);
+        dd.addParent(bi);
+        const cg = new GenericInstantiation('g', [], [ai]);
+        const dg = new GenericInstantiation('g', [], [bi]);
+        h.finalize();
+
+        const egs = [
+          new GenericInstantiation('', [], [ci]),
+          new GenericInstantiation('', [], [di]),
+        ];
+        assertNearestCommonDescendants(
+            h, [cg, dg], egs,
+            'Expected that when upper bounds unify to multiple types it results in multiple upper bound types');
+      });
+
+      test('lower bounds which unify to multiple types result in multiple lower bound types', function() {
+        const h = new TypeHierarchy();
+        h.addTypeDef('a');
+        h.addTypeDef('b');
+        const cd = h.addTypeDef('c');
+        const dd = h.addTypeDef('d');
+        const ai = new ExplicitInstantiation('a');
+        const bi = new ExplicitInstantiation('b');
+        const ci = new ExplicitInstantiation('c');
+        const di = new ExplicitInstantiation('d');
+        cd.addParent(ai);
+        cd.addParent(bi);
+        dd.addParent(ai);
+        dd.addParent(bi);
+        const cg = new GenericInstantiation('g', [ai]);
+        const dg = new GenericInstantiation('g', [bi]);
+        h.finalize();
+
+        const egs = [
+          new GenericInstantiation('', [ci]),
+          new GenericInstantiation('', [di]),
+        ];
+        assertNearestCommonDescendants(
+            h, [cg, dg], egs,
+            'Expected that when lower bounds unify to multiple types it results in multiple lower bound types');
+      });
+
+      test('upper and lower bounds which unify to multiple types result in multiple upper and lower bound types', function() {
+        const h = new TypeHierarchy();
+        h.addTypeDef('a');
+        h.addTypeDef('b');
+        const cd = h.addTypeDef('c');
+        const dd = h.addTypeDef('d');
+        const ai = new ExplicitInstantiation('a');
+        const bi = new ExplicitInstantiation('b');
+        const ci = new ExplicitInstantiation('c');
+        const di = new ExplicitInstantiation('d');
+        cd.addParent(ai);
+        cd.addParent(bi);
+        dd.addParent(ai);
+        dd.addParent(bi);
+        const cg = new GenericInstantiation('g', [ai], [ai]);
+        const dg = new GenericInstantiation('g', [bi], [bi]);
+        h.finalize();
+
+        const egs = [
+          new GenericInstantiation('', [ci], [ci]),
+          new GenericInstantiation('', [ci], [di]),
+          new GenericInstantiation('', [di], [ci]),
+          new GenericInstantiation('', [di], [di]),
+        ];
+        assertNearestCommonDescendants(
+            h, [cg, dg], egs,
+            'Expected that when upper and lower bounds unify to multiple types it results in multiple upper and lower bound types');
+      });
     });
   });
 });


### PR DESCRIPTION
### :clap: Resolves

<!-- The github issue this PR is for. If this PR closes the issue please
     put the word "Closes" before the issue -->

N/A
     
### :star2: Description

<!-- A description of what your PR does -->
Adds support for handling constrained generics in NCA and NCD.

Note that:
  * If the bounds unify to multiple types, we return mulitple constrained generics to represent an "or" relation. "and" relations don't have the correct semantics in this case, because when the explicit types are unified, it will result in multiple unified types, not a single type which fulfills all constraints.
  * If we have some constrained types and some bounded types, the explicit types are included when calculating bounds. For example, if we have a upper bounded type and an explicit, we include the explicit when we are trying to find the upper bound, because whatever explicit types eventually replace the generics will also be unified with the existing explicit.

I also reorganized a bunch of logic to hopefully make it more readable.

### :bug: Testing

<!-- A list of steps you used for testing, or a list of unit tests you added. -->
So many unit tests. Definitely the most trying suite yet hehe.

### :thought_balloon: Other info

<!-- Links to other relevant issues, pull requests, or information -->
N/A