### PR TITLE
feat: subtyping for explicit parameterized types

### DIFF
--- a/src/exceptions.ts
+++ b/src/exceptions.ts
@@ -18,3 +18,11 @@ export class NotFinalized extends Error {
     super('The TypeHierarchy has not been finalized');
   }
 }
+
+export class IncompatibleVariance extends Error {
+  constructor(typeA, typeB, paramA, paramB, varianceA, varianceB) {
+    super(`The type ${typeA} with parameter ${paramA} with variance ` +
+        `${varianceA} cannot fulfill ${typeB} with ${paramB} with variance ` +
+        `${varianceB}`);
+  }
+}

--- a/src/parameter_definition.ts
+++ b/src/parameter_definition.ts
@@ -4,12 +4,11 @@
  * SPDX-License-Identifier: MIT
  */
 
-export interface ParameterDefinition {
-  readonly name: string;
-  readonly variance: Variance;
+export class ParameterDefinition {
+  constructor(readonly name: string, readonly variance: Variance) {}
 }
 
-enum Variance {
+export enum Variance {
   CO = 'COVARIANT',
   CONTRA = 'CONTRAVARIANT',
   INV = 'INVARIANT'

--- a/src/type_definition.ts
+++ b/src/type_definition.ts
@@ -6,7 +6,7 @@
 
 import {ParameterDefinition} from './parameter_definition';
 import {TypeHierarchy} from './type_hierarchy';
-import {ExplicitInstantiation, TypeInstantiation} from './type_instantiation';
+import {ExplicitInstantiation, GenericInstantiation, TypeInstantiation} from './type_instantiation';
 import {IncompatibleType} from './exceptions';
 
 export class TypeDefinition {
@@ -14,11 +14,11 @@ export class TypeDefinition {
   private readonly children_: TypeInstantiation[] = [];
   private readonly ancestors_: TypeInstantiation[] = [];
   private readonly descendants_: TypeInstantiation[] = [];
-  private readonly params_: ParameterDefinition[] = [];
 
   constructor(
       readonly hierarchy: TypeHierarchy,
-      readonly name: string
+      readonly name: string,
+      private readonly params_: ParameterDefinition[] = []
   ) {
     this.ancestors_.push(this.createInstance());
     this.descendants_.push(this.createInstance());
@@ -93,6 +93,7 @@ export class TypeDefinition {
   }
 
   createInstance(): ExplicitInstantiation {
-    return new ExplicitInstantiation(this.name);
+    return new ExplicitInstantiation(
+        this.name, this.params_.map(p => new GenericInstantiation()));
   }
 }

--- a/src/type_definition.ts
+++ b/src/type_definition.ts
@@ -88,14 +88,15 @@ export class TypeDefinition {
     this.ancestors_.push(a);
     const parentToAncestor = parent.getParamsForAncestor(a.name);
     const thisToParent = this.getParamsForAncestor(parent.name);
-    const thisToAncestor = [];
-    parentToAncestor.forEach((p) => {
+    const replaceFn = (p) => {
       if (p instanceof GenericInstantiation) {
-        thisToAncestor.push(thisToParent[parent.getIndexOfParam(p.name)]);
+        return thisToParent[parent.getIndexOfParam(p.name)];
       } else {
-        thisToAncestor.push(p);
+        p.params = p.params.map(replaceFn);
+        return p;
       }
-    });
+    };
+    const thisToAncestor = parentToAncestor.map(replaceFn);
     this.ancestorParamsMap_.set(a.name, thisToAncestor);
     this.children_.forEach(
         c => this.hierarchy.getTypeDef(c.name).addAncestor(a, this));

--- a/src/type_hierarchy.ts
+++ b/src/type_hierarchy.ts
@@ -8,6 +8,7 @@ import {TypeDefinition} from './type_definition';
 import {ExplicitInstantiation, GenericInstantiation, TypeInstantiation} from './type_instantiation';
 import {removeDuplicates} from './utils';
 import {IncompatibleType, NotFinalized} from './exceptions';
+import {ParameterDefinition} from "./parameter_definition";
 
 export class TypeHierarchy {
   /**
@@ -174,11 +175,11 @@ export class TypeHierarchy {
   }
 
   /**
-   * Adds a new type definition with the given name to this type hierarchy, and
-   * returns the type definition.
+   * Adds a new type definition with the given name (and optional parameter
+   * definitions) to this type hierarchy, and returns the type definition.
    */
-  addTypeDef(n: string): TypeDefinition {
-    const d = new TypeDefinition(this, n);
+  addTypeDef(n: string, ps: ParameterDefinition[] = []): TypeDefinition {
+    const d = new TypeDefinition(this, n, ps);
     this.typeDefsMap.set(n, d);
     return d;
   }

--- a/src/type_hierarchy.ts
+++ b/src/type_hierarchy.ts
@@ -4,11 +4,11 @@
  * SPDX-License-Identifier: MIT
  */
 
-import {TypeDefinition} from './type_definition';
 import {ExplicitInstantiation, GenericInstantiation, TypeInstantiation} from './type_instantiation';
-import {removeDuplicates} from './utils';
 import {IncompatibleType, NotFinalized} from './exceptions';
-import {ParameterDefinition, Variance} from "./parameter_definition";
+import {ParameterDefinition, Variance} from './parameter_definition';
+import {TypeDefinition} from './type_definition';
+import {removeDuplicates} from './utils';
 
 export class TypeHierarchy {
   /**
@@ -159,9 +159,9 @@ export class TypeHierarchy {
    * have descendants in the array.
    */
   private removeDescendants() {
-    return (t1, i, arr) =>
+    return (t1: TypeInstantiation, i: number, arr: TypeInstantiation[]) =>
       arr.every(
-          (t2, j) => i == j || !this.getTypeDef(t1.name).hasDescendant(t2));
+          (t2, j) => i == j || !this.getTypeDef(t1.name).hasDescendant(t2.name));
   }
 
   /**
@@ -169,9 +169,9 @@ export class TypeHierarchy {
    * have ancestors in the array.
    */
   private removeAncestors() {
-    return (t1, i, arr) =>
+    return (t1: TypeInstantiation, i: number, arr: TypeInstantiation[]) =>
       arr.every(
-          (t2, j) => i == j || !this.getTypeDef(t1.name).hasAncestor(t2));
+          (t2, j) => i == j || !this.getTypeDef(t1.name).hasAncestor(t2.name));
   }
 
   /**

--- a/src/type_instantiation.ts
+++ b/src/type_instantiation.ts
@@ -11,13 +11,12 @@ export interface TypeInstantiation {
 }
 
 export class ExplicitInstantiation implements TypeInstantiation {
-  readonly name: string;
-  readonly params: readonly TypeInstantiation[];
   readonly hasParams: boolean;
 
-  constructor(name: string, params: TypeInstantiation[] = []) {
-    this.name = name;
-    this.params = params;
+  constructor(
+      readonly name: string,
+      readonly params: TypeInstantiation[] = []
+  ) {
     this.hasParams = !!params.length;
   }
 

--- a/test/subtyping.mocha.js
+++ b/test/subtyping.mocha.js
@@ -857,7 +857,7 @@ suite('Subtyping', function() {
     });
   });
 
-  suite.only('explicit parameterized subtyping', function() {
+  suite('explicit parameterized subtyping', function() {
     suite('covariant types', function() {
       test('unrelated outers do not fulfill types', function() {
         const h = new TypeHierarchy();

--- a/test/subtyping.mocha.js
+++ b/test/subtyping.mocha.js
@@ -1443,19 +1443,19 @@ suite('Subtyping', function() {
 
         const coChildDef = h.addTypeDef('childCo', [coParam]);
         const coDef = h.addTypeDef('co', [coParam]);
-        const coParentDef = h.addTypeDef('praentCo', [coParam]);
+        const coParentDef = h.addTypeDef('parentCo', [coParam]);
         coChildDef.addParent(coDef.createInstance());
         coDef.addParent(coParentDef.createInstance());
 
         const contraChildDef = h.addTypeDef('childContra', [contraParam]);
-        const contraDef = h.addTypeDef('contra', [coParam]);
-        const contraParentDef = h.addTypeDef('parentContra', [coParam]);
+        const contraDef = h.addTypeDef('contra', [contraParam]);
+        const contraParentDef = h.addTypeDef('parentContra', [contraParam]);
         contraChildDef.addParent(contraDef.createInstance());
         contraDef.addParent(contraParentDef.createInstance());
 
         const invChildDef = h.addTypeDef('childInv', [invParam]);
         const invDef = h.addTypeDef('inv', [invParam]);
-        const invParentDef = h.addTypeDef('parentInv', [coParam]);
+        const invParentDef = h.addTypeDef('parentInv', [invParam]);
         invChildDef.addParent(invDef.createInstance());
         invDef.addParent(invParentDef.createInstance());
 
@@ -1484,7 +1484,7 @@ suite('Subtyping', function() {
             'Expected co[childCo[child]] to fulfill co[co[type]]');
       });
 
-      test('co[childContra[parent]] fulfills co{contra[type]]', function() {
+      test('co[childContra[parent]] fulfills co[contra[type]]', function() {
         const h = defineNestedHierarchy();
         const a = new ExplicitInstantiation(
             'co', [new ExplicitInstantiation(
@@ -1579,7 +1579,7 @@ suite('Subtyping', function() {
                 'contra', [new ExplicitInstantiation(
                     'inv', [new ExplicitInstantiation('type')])]);
 
-            assert.isTrue(
+            assert.isFalse(
                 h.typeFulfillsType(a, b),
                 'Expected contra[parentInv[parent]] to not fulfill contra[inv[type]]');
           });

--- a/test/type_definition.mocha.js
+++ b/test/type_definition.mocha.js
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: MIT
  */
 
-import {IncompatibleType} from '../src/exceptions';
+import {IncompatibleType, IncompatibleVariance} from '../src/exceptions';
 import {TypeHierarchy} from '../src/type_hierarchy';
 import {
   ExplicitInstantiation,
@@ -267,5 +267,119 @@ suite('TypeDefinition', function() {
   });
 
   suite('variance inheritance', function() {
+    test('co can inherit from co', function() {
+      const h = new TypeHierarchy();
+      const ap = new ParameterDefinition('a', Variance.CO);
+      const bp = new ParameterDefinition('b', Variance.CO);
+      const ad = h.addTypeDef('a', [ap]);
+      h.addTypeDef('b', [bp]);
+      const bi = new ExplicitInstantiation('b', [new GenericInstantiation('a')]);
+
+      assert.doesNotThrow(() => ad.addParent(bi));
+    });
+
+    test('co cannot inherit from contra', function() {
+      const h = new TypeHierarchy();
+      const ap = new ParameterDefinition('a', Variance.CO);
+      const bp = new ParameterDefinition('b', Variance.CONTRA);
+      const ad = h.addTypeDef('a', [ap]);
+      h.addTypeDef('b', [bp]);
+      const bi = new ExplicitInstantiation('b', [new GenericInstantiation('a')]);
+
+      assert.throws(
+          () => ad.addParent(bi),
+          new RegExp('The type a with parameter a with variance .* cannot ' +
+              'fulfill b with b with variance .*'),
+          IncompatibleVariance);
+    });
+
+    test('co cannot inherit from inv', function() {
+      const h = new TypeHierarchy();
+      const ap = new ParameterDefinition('a', Variance.CO);
+      const bp = new ParameterDefinition('b', Variance.INV);
+      const ad = h.addTypeDef('a', [ap]);
+      h.addTypeDef('b', [bp]);
+      const bi = new ExplicitInstantiation('b', [new GenericInstantiation('a')]);
+
+      assert.throws(
+          () => ad.addParent(bi),
+          new RegExp('The type a with parameter a with variance .* cannot ' +
+              'fulfill b with b with variance .*'),
+          IncompatibleVariance);
+    });
+
+    test('contra cannot inherit from co', function() {
+      const h = new TypeHierarchy();
+      const ap = new ParameterDefinition('a', Variance.CONTRA);
+      const bp = new ParameterDefinition('b', Variance.CO);
+      const ad = h.addTypeDef('a', [ap]);
+      h.addTypeDef('b', [bp]);
+      const bi = new ExplicitInstantiation('b', [new GenericInstantiation('a')]);
+
+      assert.throws(
+          () => ad.addParent(bi),
+          new RegExp('The type a with parameter a with variance .* cannot ' +
+              'fulfill b with b with variance .*'),
+          IncompatibleVariance);
+    });
+
+    test('contra can inherit from contra', function() {
+      const h = new TypeHierarchy();
+      const ap = new ParameterDefinition('a', Variance.CONTRA);
+      const bp = new ParameterDefinition('b', Variance.CONTRA);
+      const ad = h.addTypeDef('a', [ap]);
+      h.addTypeDef('b', [bp]);
+      const bi = new ExplicitInstantiation('b', [new GenericInstantiation('a')]);
+
+      assert.doesNotThrow(() => ad.addParent(bi));
+    });
+
+    test('contra cannot inherit from inv', function() {
+      const h = new TypeHierarchy();
+      const ap = new ParameterDefinition('a', Variance.CONTRA);
+      const bp = new ParameterDefinition('b', Variance.INV);
+      const ad = h.addTypeDef('a', [ap]);
+      h.addTypeDef('b', [bp]);
+      const bi = new ExplicitInstantiation('b', [new GenericInstantiation('a')]);
+
+      assert.throws(
+          () => ad.addParent(bi),
+          new RegExp('The type a with parameter a with variance .* cannot ' +
+              'fulfill b with b with variance .*'),
+          IncompatibleVariance);
+    });
+
+    test('inv can inherit from co', function() {
+      const h = new TypeHierarchy();
+      const ap = new ParameterDefinition('a', Variance.INV);
+      const bp = new ParameterDefinition('b', Variance.CO);
+      const ad = h.addTypeDef('a', [ap]);
+      h.addTypeDef('b', [bp]);
+      const bi = new ExplicitInstantiation('b', [new GenericInstantiation('a')]);
+
+      assert.doesNotThrow(() => ad.addParent(bi));
+    });
+
+    test('inv can inherit from contra', function() {
+      const h = new TypeHierarchy();
+      const ap = new ParameterDefinition('a', Variance.INV);
+      const bp = new ParameterDefinition('b', Variance.CONTRA);
+      const ad = h.addTypeDef('a', [ap]);
+      h.addTypeDef('b', [bp]);
+      const bi = new ExplicitInstantiation('b', [new GenericInstantiation('a')]);
+
+      assert.doesNotThrow(() => ad.addParent(bi));
+    });
+
+    test('inv can inherit from inv', function() {
+      const h = new TypeHierarchy();
+      const ap = new ParameterDefinition('a', Variance.INV);
+      const bp = new ParameterDefinition('b', Variance.INV);
+      const ad = h.addTypeDef('a', [ap]);
+      h.addTypeDef('b', [bp]);
+      const bi = new ExplicitInstantiation('b', [new GenericInstantiation('a')]);
+
+      assert.doesNotThrow(() => ad.addParent(bi));
+    });
   });
 });

--- a/test/type_definition.mocha.js
+++ b/test/type_definition.mocha.js
@@ -6,8 +6,12 @@
 
 import {IncompatibleType} from '../src/exceptions';
 import {TypeHierarchy} from '../src/type_hierarchy';
-import {ExplicitInstantiation} from '../src/type_instantiation';
+import {
+  ExplicitInstantiation,
+  GenericInstantiation
+} from '../src/type_instantiation';
 import {assert} from 'chai';
+import {ParameterDefinition, Variance} from "../src/parameter_definition";
 
 suite('TypeDefinition', function() {
   test('every type definition is an ancestor of itself', function() {
@@ -15,7 +19,7 @@ suite('TypeDefinition', function() {
     const t = h.addTypeDef('t');
 
     assert.isTrue(
-        t.hasAncestor(new ExplicitInstantiation('t')),
+        t.hasAncestor('t'),
         'Expected the type definition to be an ancestor of itself');
   });
 
@@ -24,7 +28,7 @@ suite('TypeDefinition', function() {
     const t = h.addTypeDef('t');
 
     assert.isTrue(
-        t.hasDescendant(new ExplicitInstantiation('t')),
+        t.hasDescendant('t'),
         'Expected the type definition to be a descendant of itself');
   });
 
@@ -33,19 +37,18 @@ suite('TypeDefinition', function() {
       const h = new TypeHierarchy();
       const cd = h.addTypeDef('c');
       const pd = h.addTypeDef('p');
-      const ci = new ExplicitInstantiation('c');
       const pi = new ExplicitInstantiation('p');
 
       cd.addParent(pi);
 
       assert.isTrue(
-          cd.hasParent(pi), 'Expected the child to have a parent');
+          cd.hasParent('p'), 'Expected the child to have a parent');
       assert.isTrue(
-          cd.hasAncestor(pi), 'Expected the child to have an ancestor');
+          cd.hasAncestor('p'), 'Expected the child to have an ancestor');
       assert.isTrue(
-          pd.hasChild(ci), 'Expected the parent to have a child');
+          pd.hasChild('c'), 'Expected the parent to have a child');
       assert.isTrue(
-          pd.hasDescendant(ci), 'Expected the parent to have a descendant');
+          pd.hasDescendant('c'), 'Expected the parent to have a descendant');
     });
 
     test('if the parent does not exist, an error is thrown', function() {
@@ -86,7 +89,6 @@ suite('TypeDefinition', function() {
       const td = h.addTypeDef('t');
       const pd = h.addTypeDef('p');
       const gpd = h.addTypeDef('gp');
-      const ti = new ExplicitInstantiation('t');
       const pi = new ExplicitInstantiation('p');
       const gpi = new ExplicitInstantiation('gp');
       pd.addParent(gpi);
@@ -94,16 +96,16 @@ suite('TypeDefinition', function() {
       td.addParent(pi);
 
       assert.isFalse(
-          td.hasParent(gpi),
+          td.hasParent('gp'),
           'Expected the grandparent type to not be a parent');
       assert.isTrue(
-          td.hasAncestor(gpi),
+          td.hasAncestor('gp'),
           'Expected the grandparent type to be an ancestor');
       assert.isFalse(
-          gpd.hasChild(ti),
+          gpd.hasChild('t'),
           'Expected the type to not be a child of the grandparent');
       assert.isTrue(
-          gpd.hasDescendant(ti),
+          gpd.hasDescendant('t'),
           'Expected the type to be a descendant of the grandparent');
     });
 
@@ -114,17 +116,16 @@ suite('TypeDefinition', function() {
           const cd = h.addTypeDef('c');
           const pd = h.addTypeDef('p');
           const ti = new ExplicitInstantiation('t');
-          const ci = new ExplicitInstantiation('c');
           const pi = new ExplicitInstantiation('p');
           cd.addParent(ti);
 
           td.addParent(pi);
 
           assert.isTrue(
-              cd.hasAncestor(pi),
+              cd.hasAncestor('p'),
               'Expected the parent to be an ancestor of the child');
           assert.isTrue(
-              pd.hasDescendant(ci),
+              pd.hasDescendant('c'),
               'Expected the child to be a descendant of the parent');
         });
 
@@ -183,5 +184,88 @@ suite('TypeDefinition', function() {
               1,
               'Expected the descendant to only exist once');
         });
+  });
+
+  suite('reorganizing params for ancestors', function() {
+    function assertParamOrder(type, ancestor, params, msg) {
+      const mappedParams = type.getParamsForAncestor(ancestor);
+      assert.equal(mappedParams.length, params.length, msg);
+      assert.deepEqual(mappedParams, params, msg);
+    }
+
+    test('params for self are identical', function() {
+      const h = new TypeHierarchy();
+      const pa = new ParameterDefinition('a', Variance.CO);
+      const pb = new ParameterDefinition('b', Variance.CO);
+      const x = h.addTypeDef('x', [pa, pb]);
+      h.finalize();
+
+      assertParamOrder(
+          x, 'x', [new GenericInstantiation('a'), new GenericInstantiation('b')],
+          'Expected the param mapping from a type to itself to be identical to its normal params list');
+    });
+
+    test('params are properly reorganized for parent', function() {
+      const h = new TypeHierarchy();
+      const pa = new ParameterDefinition('a', Variance.CO);
+      const pb = new ParameterDefinition('b', Variance.CO);
+      const x = h.addTypeDef('x', [pa, pb]);
+      const y = h.addTypeDef('y', [pb, pa]);
+      x.addParent(y.createInstance());
+      h.finalize();
+
+      assertParamOrder(
+          x, 'y', [new GenericInstantiation('b'), new GenericInstantiation('a')],
+          'Expected params to be properly reorganized for the parent type');
+    });
+
+    test('params are properly reorganized for ancestor', function() {
+      const h = new TypeHierarchy();
+      const pa = new ParameterDefinition('a', Variance.CO);
+      const pb = new ParameterDefinition('b', Variance.CO);
+      const pc = new ParameterDefinition('c', Variance.CO);
+      const x = h.addTypeDef('x', [pa, pb, pc]);
+      const y = h.addTypeDef('y', [pc, pa, pb]);
+      const z = h.addTypeDef('z', [pb, pc, pa]);
+      x.addParent(y.createInstance());
+      y.addParent(z.createInstance());
+      h.finalize();
+
+      assertParamOrder(
+          x,
+          'z',
+          [
+            new GenericInstantiation('b'),
+            new GenericInstantiation('c'),
+            new GenericInstantiation('a'),
+          ],
+          'Expected the params to be properly reorganized for the ancestor type');
+    });
+
+    test('nested params in ancestors are properly mapped', function() {
+      const h = new TypeHierarchy();
+      const pa = new ParameterDefinition('a', Variance.CO);
+      h.addTypeDef('list', [pa]);
+      const listList = h.addTypeDef('listList', [pa]);
+      listList.addParent(new ExplicitInstantiation(
+          'list', [new ExplicitInstantiation(
+              'list', [new GenericInstantiation('a')])]));
+      h.addTypeDef('dog');
+      const dogListList = h.addTypeDef('dogListList');
+      dogListList.addParent(new ExplicitInstantiation(
+          'listList', [new ExplicitInstantiation('dog')]));
+
+      assertParamOrder(
+          dogListList,
+          'list',
+          [
+            new ExplicitInstantiation(
+                'list', [new ExplicitInstantiation('dog')]),
+          ],
+          'Expected nested params to be properly reorganized for the ancestor type');
+    });
+  });
+
+  suite('variance inheritance', function() {
   });
 });


### PR DESCRIPTION
### :clap: Resolves

<!-- The github issue this PR is for. If this PR closes the issue please
     put the word "Closes" before the issue -->
     
N/A
     
### :star2: Description

<!-- A description of what your PR does -->
Adds support for handling subtyping for explicit types that have parameters. This works by recursively evaluating the parameters of the subtype to make sure they fulfill the parameters of the supertype, with proper handling of variance.

Also includes a little bit of inheritance testing in the TypeDefinitions to make sure that variance inheritance is proper (eg a covariant parameter cannot fulfill an invariant parameter).

### :bug: Testing

<!-- A list of steps you used for testing, or a list of unit tests you added. -->
Unit tests!

### :thought_balloon: Other info

<!-- Links to other relevant issues, pull requests, or information -->
N/A