### PR TITLE
feat: do not allow duplicate params in type definitions

### DIFF
--- a/src/exceptions.ts
+++ b/src/exceptions.ts
@@ -26,3 +26,9 @@ export class IncompatibleVariance extends Error {
         `${varianceB}`);
   }
 }
+
+export class DuplicateParamNames extends Error {
+  constructor(type, param) {
+    super(`The type ${type} has duplicate params with the name ${param.name}`);
+  }
+}

--- a/src/type_definition.ts
+++ b/src/type_definition.ts
@@ -7,7 +7,7 @@
 import {ParameterDefinition, Variance} from './parameter_definition';
 import {TypeHierarchy} from './type_hierarchy';
 import {ExplicitInstantiation, GenericInstantiation, TypeInstantiation} from './type_instantiation';
-import {IncompatibleType, IncompatibleVariance} from './exceptions';
+import {DuplicateParamNames, IncompatibleType, IncompatibleVariance} from './exceptions';
 
 export class TypeDefinition {
   private readonly parents_: ExplicitInstantiation[] = [];
@@ -22,6 +22,12 @@ export class TypeDefinition {
       readonly name: string,
       private readonly params_: ParameterDefinition[] = []
   ) {
+    const names = new Set();
+    for (const p of params_) {
+      if (names.has(p.name)) throw new DuplicateParamNames(this, p);
+      names.add(p.name);
+    }
+
     this.ancestors_.push(this.createInstance());
     this.ancestorParamsMap_.set(
         name, params_.map(p => new GenericInstantiation(p.name)));

--- a/test/type_definition.mocha.js
+++ b/test/type_definition.mocha.js
@@ -5,7 +5,7 @@
  */
 
 import {ExplicitInstantiation, GenericInstantiation} from '../src/type_instantiation';
-import {IncompatibleType, IncompatibleVariance} from '../src/exceptions';
+import {DuplicateParamNames, IncompatibleType, IncompatibleVariance} from '../src/exceptions';
 import {TypeHierarchy} from '../src/type_hierarchy';
 import {ParameterDefinition, Variance} from '../src/parameter_definition';
 import {assert} from 'chai';
@@ -27,6 +27,18 @@ suite('TypeDefinition', function() {
     assert.isTrue(
         t.hasDescendant('t'),
         'Expected the type definition to be a descendant of itself');
+  });
+
+  test('no duplicate params', function() {
+    const h = new TypeHierarchy();
+    assert.throws(
+        () => h.addTypeDef(
+            'test',
+            [
+              new ParameterDefinition('a', Variance.CO),
+              new ParameterDefinition('a', Variance.CO)]),
+        DuplicateParamNames,
+        /The type .* has duplicate params with the name a/);
   });
 
   suite('constructing the type graph', function() {


### PR DESCRIPTION
### :clap: Resolves

<!-- The github issue this PR is for. If this PR closes the issue please
     put the word "Closes" before the issue -->

N/A
     
### :star2: Description

<!-- A description of what your PR does -->
Adds checks to make sure that type definitions cannot have duplicate parameter names.

### :bug: Testing

<!-- A list of steps you used for testing, or a list of unit tests you added. -->
Added a unit tests to make sure the error triggers.

### :thought_balloon: Other info

<!-- Links to other relevant issues, pull requests, or information -->
N/A