### PR TITLE
feat: fix constrained generics fulfilling explicits, and how constraints interact with variance

### DIFF
--- a/test/subtyping.mocha.js
+++ b/test/subtyping.mocha.js
@@ -2073,6 +2073,7 @@ suite('Subtyping', function() {
       const invParam = new ParameterDefinition('inv', Variance.INV);
       h.addTypeDef('inv', [invParam]);
       h.addTypeDef('type');
+      h.finalize();
       const inv1 = new ExplicitInstantiation(
           'inv', [new GenericInstantiation('g')]);
       const inv2 = new ExplicitInstantiation(
@@ -2088,6 +2089,7 @@ suite('Subtyping', function() {
       const invParam = new ParameterDefinition('inv', Variance.INV);
       h.addTypeDef('inv', [invParam]);
       h.addTypeDef('type');
+      h.finalize();
       const inv1 = new ExplicitInstantiation(
           'inv', [new GenericInstantiation('g')]);
       const inv2 = new ExplicitInstantiation(
@@ -2244,7 +2246,7 @@ suite('Subtyping', function() {
           const contra1 = new ExplicitInstantiation(
               'contra', [new ExplicitInstantiation('parent')]);
           const contra2 = new ExplicitInstantiation(
-              'cntrao', [new GenericInstantiation(
+              'contra', [new GenericInstantiation(
                   't', [], [new ExplicitInstantiation('type')])]);
 
           assert.isFalse(
@@ -2405,7 +2407,7 @@ suite('Subtyping', function() {
           const inv2 = new ExplicitInstantiation(
               'inv', [new ExplicitInstantiation('child')]);
 
-          assert.isTrue(
+          assert.isFalse(
               h.typeFulfillsType(inv1, inv2),
               'Expected inv[t >: type] to fulfills inv[child]');
         });


### PR DESCRIPTION
### :clap: Resolves

<!-- The github issue this PR is for. If this PR closes the issue please
     put the word "Closes" before the issue -->

N/A
     
### :star2: Description

<!-- A description of what your PR does -->
Adds separate (ie correct) handling for constrained generic types fulfilling explicits. This treats the explicit type as an upper bound generic (with the bound being the explicit type) and re-runs the fulfills. This allows types like `T <: type` to fulfill `parent`, which wasn't working previously.

This also adds separately handling for dealing with constraints when handling parameter variance. If the type we are trying to fulfill is a constrained type, we ignore variance. Otherwise we create a constrained generic that matches the variance (upper bound for covariant, and lower bound for contravariant) where the bound is the explicit param of the type we are trying to fulfill.

### :bug: Testing

<!-- A list of steps you used for testing, or a list of unit tests you added. -->
Lots o' unit tests.

### :thought_balloon: Other info

<!-- Links to other relevant issues, pull requests, or information -->
N/A