### PR TITLE
feat: add basic typing of connections, including basic generics

### DIFF
--- a/src/connection_typer.ts
+++ b/src/connection_typer.ts
@@ -1,0 +1,15 @@
+/**
+ * @license
+ * Copyright 2021 Beka Westberg
+ * SPDX-License-Identifier: MIT
+ */
+
+import {Connection} from 'blockly';
+import {TypeInstantiation} from './type_instantiation';
+import {parseType} from './type_parser';
+
+export class ConnectionTyper {
+  getTypesOfConnection(c: Connection): TypeInstantiation {
+    return parseType(c.getCheck()[0]);
+  }
+}

--- a/src/connection_typer.ts
+++ b/src/connection_typer.ts
@@ -26,11 +26,12 @@ export class ConnectionTyper {
       c: Connection, t: GenericInstantiation
   ): TypeInstantiation[] {
     const s = c.getSourceBlock();
-    const pConn = s.outputConnection || s.previousConnection;
+    const c2 = s.outputConnection || s.previousConnection;
     // TODO: Tests for this.
-    // TODO: tests for when output does not match input type
-    if (!pConn || !pConn.targetConnection) return [new GenericInstantiation('')];
-    const pTypes = this.getTypesOfConnection(pConn.targetConnection);
+    if (!c2 || !this.getCheck(c2).equals(t) || !c2.targetConnection) {
+      return [new GenericInstantiation('')];
+    }
+    const pTypes = this.getTypesOfConnection(c2.targetConnection);
     // TODO: How do we handle multiple types?
     if (pTypes[0] instanceof ExplicitInstantiation) {
       return [new GenericInstantiation('', [], pTypes)];

--- a/src/connection_typer.ts
+++ b/src/connection_typer.ts
@@ -4,12 +4,61 @@
  * SPDX-License-Identifier: MIT
  */
 
-import {Connection} from 'blockly';
-import {TypeInstantiation} from './type_instantiation';
+import {Block, Connection} from 'blockly';
+import {TypeHierarchy} from './type_hierarchy';
+import {ExplicitInstantiation, GenericInstantiation, TypeInstantiation} from './type_instantiation';
 import {parseType} from './type_parser';
 
 export class ConnectionTyper {
-  getTypesOfConnection(c: Connection): TypeInstantiation {
+  constructor(
+      readonly hierarchy: TypeHierarchy,
+  ) {}
+
+  getTypesOfConnection(c: Connection): TypeInstantiation[] {
+    const t = this.getCheck(c);
+    // TODO: Handling parameterized yptes.
+    if (t instanceof ExplicitInstantiation) return [t];
+    if (c.isSuperior()) return this.getTypesOfInput(c, t as GenericInstantiation);
+    return this.getTypesOfOutput(c, t as GenericInstantiation);
+  }
+
+  private getTypesOfInput(
+      c: Connection, t: GenericInstantiation
+  ): TypeInstantiation[] {
+    const s = c.getSourceBlock();
+    const pConn = s.outputConnection || s.previousConnection;
+    // TODO: Tests for this.
+    // TODO: tests for when output does not match input type
+    if (!pConn || !pConn.targetConnection) return [new GenericInstantiation('')];
+    const pTypes = this.getTypesOfConnection(pConn.targetConnection);
+    // TODO: How do we handle multiple types?
+    if (pTypes[0] instanceof ExplicitInstantiation) {
+      return [new GenericInstantiation('', [], pTypes)];
+    }
+    return pTypes;
+  }
+
+  private getTypesOfOutput(
+      c: Connection, t: GenericInstantiation
+  ): TypeInstantiation[] {
+    const s = c.getSourceBlock();
+    const matches = this.getInputConnections(s).reduce((acc, c2) => {
+      if (!this.getCheck(c2).equals(t) || !c2.targetConnection) return acc;
+      // TODO: Not sure if we need to do an explicit test like inputs.
+      return [...acc, ...this.getTypesOfConnection(c2.targetConnection)];
+    }, [] as TypeInstantiation[]);
+    if (matches.length) {
+      return this.hierarchy.getNearestCommonAncestors(...matches);
+    }
+    return [new GenericInstantiation(
+        '', t.unfilteredLowerBounds, t.unfilteredUpperBounds)];
+  }
+
+  private getInputConnections(b: Block): Connection[] {
+    return b.inputList.map(i => i.connection);
+  }
+
+  private getCheck(c: Connection) {
     return parseType(c.getCheck()[0]);
   }
 }

--- a/src/type_hierarchy.ts
+++ b/src/type_hierarchy.ts
@@ -355,6 +355,7 @@ export class TypeHierarchy {
     });
 
     if (types.length == 0) return [];
+    if (types.length == 1) return types;
     types = types.filter(t =>
       t instanceof ExplicitInstantiation ||
       t instanceof GenericInstantiation && t.isConstrained);

--- a/test/connection_typing.mocha.js
+++ b/test/connection_typing.mocha.js
@@ -1,0 +1,87 @@
+/**
+ * @license
+ * Copyright 2021 Beka Westberg
+ * SPDX-License-Identifier: MIT
+ */
+
+import {ConnectionTyper} from '../src/connection_typer';
+import * as Blockly from 'blockly';
+import {assert} from 'chai';
+import {ExplicitInstantiation, GenericInstantiation} from '../src/type_instantiation';
+
+suite('Connection typing', function() {
+  let workspace;
+  let connectionTyper;
+
+  function createBlock(name, output = '', inputs = []) {
+    Blockly.Blocks[name] = {
+      init: function() {
+        if (output) this.setOutput(true, output);
+        inputs.forEach((input, i) => {
+          this.appendValueInput(i).setCheck(input);
+        });
+      },
+    };
+    return workspace.newBlock(name);
+  }
+
+  function assertConnectionType(conn, types) {
+    assert.deepEqual(connectionTyper.getTypesOfConnection(conn), types);
+  }
+
+  setup(function() {
+    workspace = new Blockly.Workspace();
+    connectionTyper = new ConnectionTyper();
+  });
+
+  teardown(function() {
+    for (const block in Blockly.Blocks) {
+      if (Object.prototype.hasOwnProperty.call(Blockly.Blocks, block)) {
+        delete Blockly.Blocks[block];
+      }
+    }
+    workspace.dispose();
+  });
+
+  suite('basic typing (no connected blocks)', function() {
+    test('typing an explicit type', function() {
+      const block = createBlock('test', 'test');
+      assertConnectionType(
+          block.outputConnection, new ExplicitInstantiation('test'));
+    });
+
+    test('typing an explicit type with params', function() {
+      const block = createBlock('test', 'test[test2, test3]');
+      assertConnectionType(
+          block.outputConnection,
+          new ExplicitInstantiation(
+              'test',
+              [
+                new ExplicitInstantiation('test2'),
+                new ExplicitInstantiation('test3'),
+              ]));
+    });
+
+    test('typing a generic type', function() {
+      const block = createBlock('test', 't');
+      assertConnectionType(
+          block.outputConnection, new GenericInstantiation('t'));
+    });
+
+    test('typing a generic type with bounds', function() {
+      const block = createBlock('test', 'test1, test2 <: t <: test3, test4');
+      assertConnectionType(
+          block.outputConnection,
+          new GenericInstantiation(
+              't',
+              [
+                new ExplicitInstantiation('test1'),
+                new ExplicitInstantiation('test2'),
+              ],
+              [
+                new ExplicitInstantiation('test3'),
+                new ExplicitInstantiation('test4'),
+              ]));
+    });
+  });
+});

--- a/test/connection_typing.mocha.js
+++ b/test/connection_typing.mocha.js
@@ -5,33 +5,51 @@
  */
 
 import {ConnectionTyper} from '../src/connection_typer';
-import * as Blockly from 'blockly';
-import {assert} from 'chai';
 import {ExplicitInstantiation, GenericInstantiation} from '../src/type_instantiation';
+import {TypeHierarchy} from '../src/type_hierarchy';
+import {assert} from 'chai';
+import * as Blockly from 'blockly';
 
-suite('Connection typing', function() {
+suite.only('Connection typing', function() {
+  class TestConnectionChecker extends Blockly.ConnectionChecker {
+    doTypeChecks() {
+      return true;
+    }
+  }
+  const type = Blockly.registry.Type.CONNECTION_CHECKER;
+  const name = 'TestConnectionChecker';
+  Blockly.registry.register(type, name, TestConnectionChecker);
+
   let workspace;
-  let connectionTyper;
 
   function createBlock(name, output = '', inputs = []) {
     Blockly.Blocks[name] = {
       init: function() {
         if (output) this.setOutput(true, output);
         inputs.forEach((input, i) => {
-          this.appendValueInput(i).setCheck(input);
+          this.appendValueInput(`${i}`).setCheck(input);
         });
       },
     };
     return workspace.newBlock(name);
   }
 
-  function assertConnectionType(conn, types) {
-    assert.deepEqual(connectionTyper.getTypesOfConnection(conn), types);
+  function assertConnectionType(typer, conn, types, msg) {
+    assert.deepEqual(typer.getTypesOfConnection(conn), types, msg);
+  }
+
+  function blankHierarchy() {
+    const h = new TypeHierarchy();
+    h.finalize();
+    return h;
   }
 
   setup(function() {
-    workspace = new Blockly.Workspace();
-    connectionTyper = new ConnectionTyper();
+    workspace = new Blockly.Workspace({
+      plugins: {
+        [type]: name,
+      },
+    });
   });
 
   teardown(function() {
@@ -45,35 +63,44 @@ suite('Connection typing', function() {
 
   suite('basic typing (no connected blocks)', function() {
     test('typing an explicit type', function() {
+      const typer = new ConnectionTyper(blankHierarchy());
       const block = createBlock('test', 'test');
       assertConnectionType(
-          block.outputConnection, new ExplicitInstantiation('test'));
+          typer, block.outputConnection, [new ExplicitInstantiation('test')],
+          'Expected a basic explicit type to simply be parsed');
     });
 
     test('typing an explicit type with params', function() {
+      const typer = new ConnectionTyper(blankHierarchy());
       const block = createBlock('test', 'test[test2, test3]');
       assertConnectionType(
+          typer,
           block.outputConnection,
-          new ExplicitInstantiation(
+          [new ExplicitInstantiation(
               'test',
               [
                 new ExplicitInstantiation('test2'),
                 new ExplicitInstantiation('test3'),
-              ]));
+              ])],
+          'Expected a parameterized explicit type to simply be parsed');
     });
 
     test('typing a generic type', function() {
+      const typer = new ConnectionTyper(blankHierarchy());
       const block = createBlock('test', 't');
       assertConnectionType(
-          block.outputConnection, new GenericInstantiation('t'));
+          typer, block.outputConnection, [new GenericInstantiation('')],
+          'Expected an unattached generic output to be simply parsed');
     });
 
     test('typing a generic type with bounds', function() {
+      const typer = new ConnectionTyper(blankHierarchy());
       const block = createBlock('test', 'test1, test2 <: t <: test3, test4');
       assertConnectionType(
+          typer,
           block.outputConnection,
-          new GenericInstantiation(
-              't',
+          [new GenericInstantiation(
+              '',
               [
                 new ExplicitInstantiation('test1'),
                 new ExplicitInstantiation('test2'),
@@ -81,7 +108,129 @@ suite('Connection typing', function() {
               [
                 new ExplicitInstantiation('test3'),
                 new ExplicitInstantiation('test4'),
-              ]));
+              ])],
+          'Expected an unattached generic ouput with bounds to be simply parsed');
+    });
+  });
+
+  suite('simple generics', function() {
+    test('typing a generic input attached to a parent', function() {
+      const typer = new ConnectionTyper(blankHierarchy());
+      const parent = createBlock('parent', '', ['type']);
+      const child = createBlock('child', 'g', ['g']);
+      parent.getInput('0').connection.connect(child.outputConnection);
+      assertConnectionType(
+          typer,
+          child.getInput('0').connection,
+          [new GenericInstantiation('', [], [new ExplicitInstantiation('type')])],
+          'Expected the generic input to have a bound of <: the parent');
+    });
+
+    test('typing a generic input through another generic parent', function() {
+      const typer = new ConnectionTyper(blankHierarchy());
+      const parent = createBlock('parent', '', ['type']);
+      const middle = createBlock('middle', 't', ['t']);
+      const child = createBlock('child', 'g', ['g']);
+      parent.getInput('0').connection.connect(middle.outputConnection);
+      middle.getInput('0').connection.connect(child.outputConnection);
+      assertConnectionType(
+          typer,
+          child.getInput('0').connection,
+          [new GenericInstantiation('', [], [new ExplicitInstantiation('type')])],
+          'Expected the generic to have a bound of <: the parent');
+    });
+
+    test('typing a generic input attached to a child', function() {
+      const typer = new ConnectionTyper(blankHierarchy());
+      const parent = createBlock('parent', '', ['g']);
+      const child = createBlock('child', 'type');
+      parent.getInput('0').connection.connect(child.outputConnection);
+      assertConnectionType(
+          typer,
+          parent.getInput('0').connection,
+          [new GenericInstantiation('')],
+          'Expected the input to be a simple generic');
+    });
+
+    test('typing a generic output attached to a parent', function() {
+      const typer = new ConnectionTyper(blankHierarchy());
+      const parent = createBlock('parent', '', ['type']);
+      const child = createBlock('child', 'g', ['g']);
+      parent.getInput('0').connection.connect(child.outputConnection);
+      assertConnectionType(
+          typer,
+          child.outputConnection,
+          [new GenericInstantiation('')],
+          'Expected the output to be a simple generic');
+    });
+
+    test('typing a generic output attached to a child', function() {
+      const h = new TypeHierarchy();
+      h.addTypeDef('type');
+      h.finalize();
+      const typer = new ConnectionTyper(h);
+      const parent = createBlock('parent', 'g', ['g']);
+      const child = createBlock('child', 'type');
+      parent.getInput('0').connection.connect(child.outputConnection);
+      assertConnectionType(
+          typer,
+          parent.outputConnection,
+          [new ExplicitInstantiation('type')],
+          'Expected the generic to have the type of the child');
+    });
+
+    test('typing a generic output through another generic child', function() {
+      const h = new TypeHierarchy();
+      h.addTypeDef('type');
+      h.finalize();
+      const typer = new ConnectionTyper(h);
+      const parent = createBlock('parent', 'g', ['g']);
+      const middle = createBlock('middle', 't', ['t']);
+      const child = createBlock('child', 'type');
+      parent.getInput('0').connection.connect(middle.outputConnection);
+      middle.getInput('0').connection.connect(child.outputConnection);
+      assertConnectionType(
+          typer,
+          parent.outputConnection,
+          [new ExplicitInstantiation('type')],
+          'Expetd the generic to have the type of the child');
+    });
+
+    test('typing a generic output with multiple children', function() {
+      const h = new TypeHierarchy();
+      const a = h.addTypeDef('typeA');
+      const b = h.addTypeDef('typeB');
+      const c = h.addTypeDef('typeC');
+      b.addParent(a.createInstance());
+      c.addParent(a.createInstance());
+      h.finalize();
+      const typer = new ConnectionTyper(h);
+
+      const parent = createBlock('parent', 'g', ['g', 'g']);
+      const typeB = createBlock('b', 'typeB');
+      const typeC = createBlock('c', 'typeC');
+      parent.getInput('0').connection.connect(typeB.outputConnection);
+      parent.getInput('1').connection.connect(typeC.outputConnection);
+      assertConnectionType(
+          typer,
+          parent.outputConnection,
+          [new ExplicitInstantiation('typeA')],
+          'Expected the ouput to have the type of the NCA of the children');
+    });
+
+    test('typing a generic input with a sibling', function() {
+      const h = new TypeHierarchy();
+      h.addTypeDef('type');
+      h.finalize();
+      const typer = new ConnectionTyper(h);
+      const parent = createBlock('parent', '', ['g', 'g']);
+      const child = createBlock('child', 'type');
+      parent.getInput('0').connection.connect(child.outputConnection);
+      assertConnectionType(
+          typer,
+          parent.getInput('1').connection,
+          [new GenericInstantiation('')],
+          'Expected the generic to be a simple generic');
     });
   });
 });

--- a/test/connection_typing.mocha.js
+++ b/test/connection_typing.mocha.js
@@ -11,7 +11,7 @@ import {assert} from 'chai';
 import * as Blockly from 'blockly';
 import {ParameterDefinition, Variance} from '../src/parameter_definition';
 
-suite.only('Connection typing', function() {
+suite('Connection typing', function() {
   class TestConnectionChecker extends Blockly.ConnectionChecker {
     doTypeChecks() {
       return true;

--- a/test/connection_typing.mocha.js
+++ b/test/connection_typing.mocha.js
@@ -152,6 +152,18 @@ suite.only('Connection typing', function() {
           'Expected the input to be a simple generic');
     });
 
+    test('typing generic input with a non-matching output', function() {
+      const typer = new ConnectionTyper(blankHierarchy());
+      const parent = createBlock('parent', '', ['type']);
+      const child = createBlock('child', 't', ['g']);
+      parent.getInput('0').connection.connect(child.outputConnection);
+      assertConnectionType(
+          typer,
+          child.getInput('0').connection,
+          [new GenericInstantiation('')],
+          'Expected the ionput to be a simple generic');
+    });
+
     test('typing a generic output attached to a parent', function() {
       const typer = new ConnectionTyper(blankHierarchy());
       const parent = createBlock('parent', '', ['type']);
@@ -162,21 +174,6 @@ suite.only('Connection typing', function() {
           child.outputConnection,
           [new GenericInstantiation('')],
           'Expected the output to be a simple generic');
-    });
-
-    test('typing a generic output attached to a child', function() {
-      const h = new TypeHierarchy();
-      h.addTypeDef('type');
-      h.finalize();
-      const typer = new ConnectionTyper(h);
-      const parent = createBlock('parent', 'g', ['g']);
-      const child = createBlock('child', 'type');
-      parent.getInput('0').connection.connect(child.outputConnection);
-      assertConnectionType(
-          typer,
-          parent.outputConnection,
-          [new ExplicitInstantiation('type')],
-          'Expected the generic to have the type of the child');
     });
 
     test('typing a generic output through another generic child', function() {
@@ -194,6 +191,36 @@ suite.only('Connection typing', function() {
           parent.outputConnection,
           [new ExplicitInstantiation('type')],
           'Expetd the generic to have the type of the child');
+    });
+
+    test('typing a generic output attached to a child', function() {
+      const h = new TypeHierarchy();
+      h.addTypeDef('type');
+      h.finalize();
+      const typer = new ConnectionTyper(h);
+      const parent = createBlock('parent', 'g', ['g']);
+      const child = createBlock('child', 'type');
+      parent.getInput('0').connection.connect(child.outputConnection);
+      assertConnectionType(
+          typer,
+          parent.outputConnection,
+          [new ExplicitInstantiation('type')],
+          'Expected the generic to have the type of the child');
+    });
+
+    test('typing a generic output with only non-matching inputs', function() {
+      const h = new TypeHierarchy();
+      h.addTypeDef('type');
+      h.finalize();
+      const typer = new ConnectionTyper(h);
+      const parent = createBlock('parent', 'g', ['t']);
+      const child = createBlock('child', 'type');
+      parent.getInput('0').connection.connect(child.outputConnection);
+      assertConnectionType(
+          typer,
+          parent.outputConnection,
+          [new GenericInstantiation('')],
+          'Expected the the output to be a simple generic');
     });
 
     test('typing a generic output with multiple children', function() {

--- a/test/nearest_common_ancestors.mocha.js
+++ b/test/nearest_common_ancestors.mocha.js
@@ -500,6 +500,38 @@ suite('Nearest common ancestors', function() {
   });
 
   suite('constrained generic nearest common ancestors', function() {
+    test('single constrained generic', function() {
+      const h = new TypeHierarchy();
+      const t1 = h.addTypeDef('test1');
+      const t2 = h.addTypeDef('test2');
+      const t3 = h.addTypeDef('test3');
+      const t4 = h.addTypeDef('test4');
+      const t5 = h.addTypeDef('test5');
+      const t6 = h.addTypeDef('test6');
+      t1.addParent(t3.createInstance());
+      t1.addParent(t4.createInstance());
+      t2.addParent(t3.createInstance());
+      t2.addParent(t4.createInstance());
+      t3.addParent(t5.createInstance());
+      t3.addParent(t6.createInstance());
+      t4.addParent(t5.createInstance());
+      t4.addParent(t6.createInstance());
+      h.finalize();
+
+      const g = new GenericInstantiation(
+          'g',
+          [
+            new ExplicitInstantiation('test1'),
+            new ExplicitInstantiation('test2'),
+          ],
+          [
+            new ExplicitInstantiation('test5'),
+            new ExplicitInstantiation('test6'),
+          ]);
+      assertNearestCommonAncestors(
+          h, [g], [g], 'Expected the nca of a single constrained generic to be itself');
+    });
+
     suite('constrained generics with unconstrained generics', function() {
       test('nca of a generic and an upper bound generic is the upper bound generic',
           function() {

--- a/test/nearest_common_descendants.mocha.js
+++ b/test/nearest_common_descendants.mocha.js
@@ -495,6 +495,38 @@ suite('Nearest common descendants', function() {
   });
 
   suite('constrained generic nearest common descendants', function() {
+    test('single constrained generic', function() {
+      const h = new TypeHierarchy();
+      const t1 = h.addTypeDef('test1');
+      const t2 = h.addTypeDef('test2');
+      const t3 = h.addTypeDef('test3');
+      const t4 = h.addTypeDef('test4');
+      const t5 = h.addTypeDef('test5');
+      const t6 = h.addTypeDef('test6');
+      t1.addParent(t3.createInstance());
+      t1.addParent(t4.createInstance());
+      t2.addParent(t3.createInstance());
+      t2.addParent(t4.createInstance());
+      t3.addParent(t5.createInstance());
+      t3.addParent(t6.createInstance());
+      t4.addParent(t5.createInstance());
+      t4.addParent(t6.createInstance());
+      h.finalize();
+
+      const g = new GenericInstantiation(
+          'g',
+          [
+            new ExplicitInstantiation('test1'),
+            new ExplicitInstantiation('test2'),
+          ],
+          [
+            new ExplicitInstantiation('test5'),
+            new ExplicitInstantiation('test6'),
+          ]);
+      assertNearestCommonDescendants(
+          h, [g], [g], 'Expected the ncd of a single constrained generic to be itself');
+    });
+
     suite('constrained generics with unconstrained generics', function() {
       test('ncd of a generic and an upper bound generic is the upper bound generic',
           function() {


### PR DESCRIPTION
### :clap: Resolves

<!-- The github issue this PR is for. If this PR closes the issue please
     put the word "Closes" before the issue -->
     
N/A
     
### :star2: Description

<!-- A description of what your PR does -->
Adds basic logic for "binding" generic connections to explicit types that are provided by other blocks.

### :bug: Testing

<!-- A list of steps you used for testing, or a list of unit tests you added. -->
Unit tests :D

### :thought_balloon: Other info

<!-- Links to other relevant issues, pull requests, or information -->
I think this is more correct than the previous implementation I did. Outputs are typed based on what is attached to the block's inputs. And inputs are typed based on what is attached to the block's output.