### PR TITLE
feat: add binding of covariant generic parameters

### DIFF
--- a/src/connection_typer.ts
+++ b/src/connection_typer.ts
@@ -56,7 +56,6 @@ export class ConnectionTyper {
 
     const ats = acs.map(c => this.getCheck(c));
     const ttss = acs.map(c => getTargetTypes(c.targetConnection));
-    // TODO: Change this to use WeakMap?
     const boundTypes: TypeInstantiation[][] = gens
         .map(g =>
           ats.flatMap((at, i) =>

--- a/src/connection_typer.ts
+++ b/src/connection_typer.ts
@@ -7,6 +7,7 @@
 import {Block, Connection} from 'blockly';
 import {TypeHierarchy} from './type_hierarchy';
 import {ExplicitInstantiation, GenericInstantiation, TypeInstantiation} from './type_instantiation';
+import {combine} from './utils';
 import {parseType} from './type_parser';
 
 export class ConnectionTyper {
@@ -22,20 +23,25 @@ export class ConnectionTyper {
 
   private getTypesOfInput(c: Connection): TypeInstantiation[] {
     const t = this.getCheck(c);
-    if (t instanceof ExplicitInstantiation) return [t];
+    const gens = this.getGenericsOfType(t);
+    if (!gens.length) return [t];
 
     const s = c.getSourceBlock();
     const c2 = s.outputConnection || s.previousConnection;
-    // TODO: Tests for this.
-    if (!c2 || !this.getCheck(c2).equals(t) || !c2.targetConnection) {
+    const ot = this.getCheck(c2);
+    if (!c2 || !c2.targetConnection ||
+        !gens.some(g => this.typeContainsGeneric(ot, g))) {
       return [new GenericInstantiation('')];
     }
-    const pTypes = this.getTypesOfConnection(c2.targetConnection);
-    // TODO: How do we handle multiple types?
-    if (pTypes[0] instanceof ExplicitInstantiation) {
-      return [new GenericInstantiation('', [], pTypes)];
-    }
-    return pTypes;
+    const pts = this.getTypesOfConnection(c2.targetConnection);
+    // TOOD: Is this how they array should work? Or should we be mapping each
+    //   explicit to a new param type?
+    return gens.reduce(
+        (accts, g) =>
+          accts.flatMap(
+              a => this.replaceGenericWithTypes(
+                  a, g, pts.flatMap(p => this.getTypesBoundToGeneric(p, ot, g)))),
+        [t]);
   }
 
   private getTypesOfOutput(c: Connection): TypeInstantiation[] {
@@ -55,11 +61,73 @@ export class ConnectionTyper {
     }
   }
 
+  private getGenericsOfType(t: TypeInstantiation): GenericInstantiation[] {
+    if (t instanceof GenericInstantiation) {
+      return [t];
+    } else if (t instanceof ExplicitInstantiation) {
+      return t.params
+          // TODO: Handle duplicate generics.
+          // TODO: Handle bounds in duplicate generics.
+          .flatMap(ot => this.getGenericsOfType(ot));
+    }
+  }
+
+  private typeContainsGeneric(t: TypeInstantiation, g: GenericInstantiation) {
+    if (t instanceof GenericInstantiation) {
+      return t.isEquivalentTo(g);
+    } else if (t instanceof ExplicitInstantiation) {
+      return t.params.some(p => this.typeContainsGeneric(p, g));
+    }
+  }
+
+  private getTypesBoundToGeneric(
+      t: TypeInstantiation,
+      ref: TypeInstantiation,
+      g: GenericInstantiation
+  ): TypeInstantiation[] {
+    if (ref instanceof GenericInstantiation) {
+      return ref.isEquivalentTo(g) ? [t] : null;
+    }
+    if (ref instanceof ExplicitInstantiation &&
+        t instanceof ExplicitInstantiation) {
+      const mapped = this.hierarchy.getTypeDef(t.name)
+          .getParamsForDescendant(ref.name, t.params);
+      // TODO: Tests for nested params.
+      return ref.params.flatMap(
+          // TODO: Is this how we should be handling multiple mappings for at
+          // generic?
+          (rp, i) => mapped[i].flatMap(
+              m => this.getTypesBoundToGeneric(m, rp, g)));
+    }
+    return [];
+  }
+
+  private replaceGenericWithTypes(
+      t: TypeInstantiation,
+      g: GenericInstantiation,
+      news: TypeInstantiation[],
+  ): TypeInstantiation[] {
+    if (t instanceof GenericInstantiation) {
+      if (t.isEquivalentTo(g)) return news.map(n => n.clone());
+      return [t];
+    }
+    if (t instanceof ExplicitInstantiation) {
+      // TODO: All this needs to be tested w/ multiple params as well.
+      if (!t.params.length) return [t];
+      // Typescript can't deal w/ heterogeneous arrays :/
+      const mapped: any = t.params.map(
+          p => this.replaceGenericWithTypes(p, g, news));
+      mapped[0] = mapped[0].map(v => [v]);
+      const combos: TypeInstantiation[][] = combine(mapped);
+      return combos.map(c => new ExplicitInstantiation(t.name, c));
+    }
+  }
+
   private getInputConnections(b: Block): Connection[] {
     return b.inputList.map(i => i.connection);
   }
 
-  private getCheck(c: Connection) {
+  private getCheck(c: Connection): TypeInstantiation {
     return parseType(c.getCheck()[0]);
   }
 }

--- a/test/connection_typing.mocha.js
+++ b/test/connection_typing.mocha.js
@@ -613,7 +613,7 @@ suite('Connection typing', function() {
 
             const typer = new ConnectionTyper(h);
             const parent = createBlock('parent', 'typeA[a, b]', ['typeA[a, b]']);
-            const middle = createBlock('middle', 'typeA[a, b]', ['typeB[b]']);
+            const middle = createBlock('middle', 'typeA[a, b]', ['typeA[a, b]']);
             const child = createBlock('child', 'typeB[typeD]');
             parent.getInput('0').connection.connect(middle.outputConnection);
             middle.getInput('0').connection.connect(child.outputConnection);

--- a/test/connection_typing.mocha.js
+++ b/test/connection_typing.mocha.js
@@ -645,8 +645,7 @@ suite('Connection typing', function() {
         assertConnectionType(
             typer,
             parent.outputConnection,
-            [new ExplicitInstantiation(
-                'typeA', [new ExplicitInstantiation('typeB')])],
+            [new ExplicitInstantiation('typeB')],
             'Expected generics to be properly bound to params');
       });
 
@@ -672,8 +671,7 @@ suite('Connection typing', function() {
             assertConnectionType(
                 typer,
                 parent.outputConnection,
-                [new ExplicitInstantiation(
-                    'typeA', [new ExplicitInstantiation('typeB')])],
+                [new ExplicitInstantiation('typeB')],
                 'Expected params to be properly unified');
           });
 
@@ -691,16 +689,15 @@ suite('Connection typing', function() {
 
             const typer = new ConnectionTyper(h);
             const parent = createBlock('parent', 't', ['typeA[t]', 't']);
-            const childC = createBlock('child', 'typeC');
-            const childD = createBlock('child', 'typeA[typeD]');
+            const childC = createBlock('child', 'typeA[typeC]');
+            const childD = createBlock('child', 'typeD');
             parent.getInput('0').connection.connect(childC.outputConnection);
             parent.getInput('1').connection.connect(childD.outputConnection);
 
             assertConnectionType(
                 typer,
                 parent.outputConnection,
-                [new ExplicitInstantiation(
-                    'typeA', [new ExplicitInstantiation('typeB')])],
+                [new ExplicitInstantiation('typeB')],
                 'Expected params and generics to be properly unified');
           });
     });

--- a/test/connection_typing.mocha.js
+++ b/test/connection_typing.mocha.js
@@ -457,6 +457,27 @@ suite('Connection typing', function() {
             'Expected unbound generics to be unnamed');
       });
 
+      test('typing a paramterized input with the generic nested', function() {
+        const h = new TypeHierarchy();
+        const coParam = new ParameterDefinition('co', Variance.CO);
+        h.addTypeDef('typeA', [coParam]);
+        h.addTypeDef('typeB');
+        h.finalize();
+
+        const typer = new ConnectionTyper(h);
+        const parent = createBlock('parent', '', ['typeA[typeA[typeB]]']);
+        const child = createBlock('child', 'typeA[typeA[t]]', ['typeA[typeA[t]]']);
+        parent.getInput('0').connection.connect(child.outputConnection);
+
+        assertConnectionType(
+            typer,
+            child.getInput('0').connection,
+            [new ExplicitInstantiation(
+                'typeA', [new ExplicitInstantiation(
+                    'typeA', [new ExplicitInstantiation('typeB')])])],
+            'Expected the generic param to be properly bound, even though it is nested');
+      });
+
       test('typing a parameterized output with parameterized input', function() {
         const h = new TypeHierarchy();
         const coParam = new ParameterDefinition('co', Variance.CO);
@@ -920,6 +941,28 @@ suite('Connection typing', function() {
                     ])],
                 'Expected unbound generics to be unnamed');
           });
+
+      test('typing a paramterized output with the generic nested', function() {
+        const h = new TypeHierarchy();
+        const coParam = new ParameterDefinition('co', Variance.CO);
+        h.addTypeDef('typeA', [coParam]);
+        h.addTypeDef('typeB');
+        h.finalize();
+
+        const typer = new ConnectionTyper(h);
+        const parent = createBlock(
+            'parent', 'typeA[typeA[t]]', ['typeA[typeA[t]]']);
+        const child = createBlock('child', 'typeA[typeA[typeB]]');
+        parent.getInput('0').connection.connect(child.outputConnection);
+
+        assertConnectionType(
+            typer,
+            parent.outputConnection,
+            [new ExplicitInstantiation(
+                'typeA', [new ExplicitInstantiation(
+                    'typeA', [new ExplicitInstantiation('typeB')])])],
+            'Expected the generic param to be properly bound, even though it is nested');
+      });
     });
   });
 });

--- a/test/connection_typing.mocha.js
+++ b/test/connection_typing.mocha.js
@@ -291,7 +291,7 @@ suite('Connection typing', function() {
       const middle = createBlock('middle', 'g', ['g', 'g']);
       const typeC = createBlock('c', 'typeC');
       const typeD = createBlock('d', 'typeD');
-      const typeE = createBlock('d', 'typeE');
+      const typeE = createBlock('e', 'typeE');
       parent.getInput('0').connection.connect(typeC.outputConnection);
       parent.getInput('1').connection.connect(middle.outputConnection);
       middle.getInput('0').connection.connect(typeD.outputConnection);
@@ -319,7 +319,7 @@ suite('Connection typing', function() {
     });
   });
 
-  suite.only('generic parameterized types', function() {
+  suite('generic parameterized types', function() {
     suite('covariant', function() {
       test('typing a parameterized input with parameterized output', function() {
         const h = new TypeHierarchy();

--- a/test/connection_typing.mocha.js
+++ b/test/connection_typing.mocha.js
@@ -149,7 +149,7 @@ suite('Connection typing', function() {
       assertConnectionType(
           typer,
           child.getInput('0').connection,
-          [new GenericInstantiation('', [], [new ExplicitInstantiation('type')])],
+          [new ExplicitInstantiation('type')],
           'Expected the generic input to have a bound of <: the parent');
     });
 
@@ -163,7 +163,7 @@ suite('Connection typing', function() {
       assertConnectionType(
           typer,
           child.getInput('0').connection,
-          [new GenericInstantiation('', [], [new ExplicitInstantiation('type')])],
+          [new ExplicitInstantiation('type')],
           'Expected the generic to have a bound of <: the parent');
     });
 
@@ -402,8 +402,7 @@ suite('Connection typing', function() {
         assertConnectionType(
             typer,
             child.getInput('0').connection,
-            [new ExplicitInstantiation(
-                'typeA', [new ExplicitInstantiation('typeB')])],
+            [new ExplicitInstantiation('typeB')],
             'Expected generics to properly look at parameters');
       });
 

--- a/test/connection_typing.mocha.js
+++ b/test/connection_typing.mocha.js
@@ -321,647 +321,652 @@ suite('Connection typing', function() {
 
   suite('generic parameterized types', function() {
     suite('covariant', function() {
-      test('typing a parameterized input with parameterized output', function() {
-        const h = new TypeHierarchy();
-        const coParam = new ParameterDefinition('co', Variance.CO);
-        h.addTypeDef('typeA', [coParam]);
-        h.addTypeDef('typeB');
-        h.finalize();
+      suite('inputs', function() {
+        test('typing a parameterized input with parameterized output', function() {
+          const h = new TypeHierarchy();
+          const coParam = new ParameterDefinition('co', Variance.CO);
+          h.addTypeDef('typeA', [coParam]);
+          h.addTypeDef('typeB');
+          h.finalize();
 
-        const typer = new ConnectionTyper(h);
-        const parent = createBlock('parent', '', ['typeA[typeB]']);
-        const child = createBlock('child', 'typeA[t]', ['typeA[t]']);
-        parent.getInput('0').connection.connect(child.outputConnection);
+          const typer = new ConnectionTyper(h);
+          const parent = createBlock('parent', '', ['typeA[typeB]']);
+          const child = createBlock('child', 'typeA[t]', ['typeA[t]']);
+          parent.getInput('0').connection.connect(child.outputConnection);
 
-        assertConnectionType(
-            typer,
-            child.getInput('0').connection,
-            [new ExplicitInstantiation(
-                'typeA', [new ExplicitInstantiation('typeB')])],
-            'Expected a parameterized input to be bound to the type attached to the output');
+          assertConnectionType(
+              typer,
+              child.getInput('0').connection,
+              [new ExplicitInstantiation(
+                  'typeA', [new ExplicitInstantiation('typeB')])],
+              'Expected a parameterized input to be bound to the type attached to the output');
+        });
+
+        test('typing a parameterized input with parameterized output attached to super',
+            function() {
+              const h = new TypeHierarchy();
+              const coParamA = new ParameterDefinition('coA', Variance.CO);
+              const coParamB = new ParameterDefinition('coB', Variance.CO);
+              h.addTypeDef('typeA', [coParamA, coParamB]);
+              const b = h.addTypeDef('typeB', [coParamA]);
+              h.addTypeDef('typeC');
+              h.addTypeDef('typeD');
+              b.addParent(new ExplicitInstantiation(
+                  'typeA',
+                  [new ExplicitInstantiation('typeC'), new GenericInstantiation('coA')]));
+              h.finalize();
+
+              const typer = new ConnectionTyper(h);
+              const parent = createBlock('parent', '', ['typeA[typeC, typeD]']);
+              const child = createBlock('child', 'typeB[t]', ['typeB[t]']);
+              parent.getInput('0').connection.connect(child.outputConnection);
+
+              assertConnectionType(
+                  typer,
+                  child.getInput('0').connection,
+                  [new ExplicitInstantiation(
+                      'typeB', [new ExplicitInstantiation('typeD')])],
+                  'Expected parameters to be properly reorganized for subtypes');
+            });
+
+        test('typing a parameterized input with generic output', function() {
+          const h = new TypeHierarchy();
+          const coParam = new ParameterDefinition('co', Variance.CO);
+          h.addTypeDef('typeA', [coParam]);
+          h.addTypeDef('typeB');
+          h.finalize();
+
+          const typer = new ConnectionTyper(h);
+          const parent = createBlock('parent', '', ['typeB']);
+          const child = createBlock('child', 't', ['typeA[t]']);
+          parent.getInput('0').connection.connect(child.outputConnection);
+
+          assertConnectionType(
+              typer,
+              child.getInput('0').connection,
+              [new ExplicitInstantiation(
+                  'typeA', [new ExplicitInstantiation('typeB')])],
+              'Expected generics to be properly slotted into parameters');
+        });
+
+        test('typing a generic input with parameterized output', function() {
+          const h = new TypeHierarchy();
+          const coParam = new ParameterDefinition('co', Variance.CO);
+          h.addTypeDef('typeA', [coParam]);
+          h.addTypeDef('typeB');
+          h.finalize();
+
+          const typer = new ConnectionTyper(h);
+          const parent = createBlock('parent', '', ['typeA[typeB]']);
+          const child = createBlock('child', 'typeA[t]', ['t']);
+          parent.getInput('0').connection.connect(child.outputConnection);
+
+          assertConnectionType(
+              typer,
+              child.getInput('0').connection,
+              [new ExplicitInstantiation('typeB')],
+              'Expected generics to properly look at parameters');
+        });
+
+        test('typing a parameterized input through a parameterized parent',
+            function() {
+              const h = new TypeHierarchy();
+              const coParamA = new ParameterDefinition('coA', Variance.CO);
+              const coParamB = new ParameterDefinition('coB', Variance.CO);
+              h.addTypeDef('typeA', [coParamA, coParamB]);
+              const b = h.addTypeDef('typeB', [coParamA]);
+              h.addTypeDef('typeC');
+              h.addTypeDef('typeD');
+              b.addParent(new ExplicitInstantiation(
+                  'typeA',
+                  [
+                    new ExplicitInstantiation('typeC'),
+                    new GenericInstantiation('coA'),
+                  ]));
+              h.finalize();
+
+              const typer = new ConnectionTyper(h);
+              const parent = createBlock('parent', '', ['typeA[typeC, typeD]']);
+              const middle = createBlock('middle', 'typeA[a, b]', ['typeB[b]']);
+              const child = createBlock('child', 'typeB[t]', ['typeB[t]']);
+              parent.getInput('0').connection.connect(middle.outputConnection);
+              middle.getInput('0').connection.connect(child.outputConnection);
+
+              assertConnectionType(
+                  typer,
+                  child.getInput('0').connection,
+                  [new ExplicitInstantiation(
+                      'typeB', [new ExplicitInstantiation('typeD')])],
+                  'Expected parameters to be properly reorganized for subtypes, and to travel through blocks');
+            });
+
+        test('typing a parameterized input without associated output', function() {
+          const h = new TypeHierarchy();
+          const coParam = new ParameterDefinition('co', Variance.CO);
+          h.addTypeDef('typeA', [coParam]);
+          h.addTypeDef('typeB');
+          h.finalize();
+
+          const typer = new ConnectionTyper(h);
+          const parent = createBlock('parent', '', ['typeA[typeB]']);
+          const child = createBlock('child', 'typeA[b]', ['typeA[t]']);
+          parent.getInput('0').connection.connect(child.outputConnection);
+
+          assertConnectionType(
+              typer,
+              child.getInput('0').connection,
+              [new ExplicitInstantiation('typeA', [new GenericInstantiation('')])],
+              'Expected unbound generics to be unnamed');
+        });
+
+        test('typing a paramterized input with the generic nested', function() {
+          const h = new TypeHierarchy();
+          const coParam = new ParameterDefinition('co', Variance.CO);
+          h.addTypeDef('typeA', [coParam]);
+          h.addTypeDef('typeB');
+          h.finalize();
+
+          const typer = new ConnectionTyper(h);
+          const parent = createBlock('parent', '', ['typeA[typeA[typeB]]']);
+          const child = createBlock('child', 'typeA[typeA[t]]', ['typeA[typeA[t]]']);
+          parent.getInput('0').connection.connect(child.outputConnection);
+
+          assertConnectionType(
+              typer,
+              child.getInput('0').connection,
+              [new ExplicitInstantiation(
+                  'typeA', [new ExplicitInstantiation(
+                      'typeA', [new ExplicitInstantiation('typeB')])])],
+              'Expected the generic param to be properly bound, even though it is nested');
+        });
       });
 
-      test('typing a parameterized input with parameterized output attached to super', function() {
-        const h = new TypeHierarchy();
-        const coParamA = new ParameterDefinition('coA', Variance.CO);
-        const coParamB = new ParameterDefinition('coB', Variance.CO);
-        h.addTypeDef('typeA', [coParamA, coParamB]);
-        const b = h.addTypeDef('typeB', [coParamA]);
-        h.addTypeDef('typeC');
-        h.addTypeDef('typeD');
-        b.addParent(new ExplicitInstantiation(
-            'typeA',
-            [new ExplicitInstantiation('typeC'), new GenericInstantiation('coA')]));
-        h.finalize();
+      suite('outputs', function() {
+        test('typing a parameterized output with parameterized input', function() {
+          const h = new TypeHierarchy();
+          const coParam = new ParameterDefinition('co', Variance.CO);
+          h.addTypeDef('typeA', [coParam]);
+          h.addTypeDef('typeB');
+          h.finalize();
 
-        const typer = new ConnectionTyper(h);
-        const parent = createBlock('parent', '', ['typeA[typeC, typeD]']);
-        const child = createBlock('child', 'typeB[t]', ['typeB[t]']);
-        parent.getInput('0').connection.connect(child.outputConnection);
+          const typer = new ConnectionTyper(h);
+          const parent = createBlock('parent', 'typeA[t]', ['typeA[t]']);
+          const child = createBlock('child', 'typeA[typeB]');
+          parent.getInput('0').connection.connect(child.outputConnection);
 
-        assertConnectionType(
-            typer,
-            child.getInput('0').connection,
-            [new ExplicitInstantiation(
-                'typeB', [new ExplicitInstantiation('typeD')])],
-            'Expected parameters to be properly reorganized for subtypes');
-      });
+          assertConnectionType(
+              typer,
+              parent.outputConnection,
+              [new ExplicitInstantiation(
+                  'typeA', [new ExplicitInstantiation('typeB')])],
+              'Expected a parameterized output to be bound to the type attached to the input');
+        });
 
-      test('typing a parameterized input with generic output', function() {
-        const h = new TypeHierarchy();
-        const coParam = new ParameterDefinition('co', Variance.CO);
-        h.addTypeDef('typeA', [coParam]);
-        h.addTypeDef('typeB');
-        h.finalize();
-
-        const typer = new ConnectionTyper(h);
-        const parent = createBlock('parent', '', ['typeB']);
-        const child = createBlock('child', 't', ['typeA[t]']);
-        parent.getInput('0').connection.connect(child.outputConnection);
-
-        assertConnectionType(
-            typer,
-            child.getInput('0').connection,
-            [new ExplicitInstantiation(
-                'typeA', [new ExplicitInstantiation('typeB')])],
-            'Expected generics to be properly slotted into parameters');
-      });
-
-      test('typing a generic input with parameterized output', function() {
-        const h = new TypeHierarchy();
-        const coParam = new ParameterDefinition('co', Variance.CO);
-        h.addTypeDef('typeA', [coParam]);
-        h.addTypeDef('typeB');
-        h.finalize();
-
-        const typer = new ConnectionTyper(h);
-        const parent = createBlock('parent', '', ['typeA[typeB]']);
-        const child = createBlock('child', 'typeA[t]', ['t']);
-        parent.getInput('0').connection.connect(child.outputConnection);
-
-        assertConnectionType(
-            typer,
-            child.getInput('0').connection,
-            [new ExplicitInstantiation('typeB')],
-            'Expected generics to properly look at parameters');
-      });
-
-      test('typing a parameterized input through a parameterized parent',
-          function() {
-            const h = new TypeHierarchy();
-            const coParamA = new ParameterDefinition('coA', Variance.CO);
-            const coParamB = new ParameterDefinition('coB', Variance.CO);
-            h.addTypeDef('typeA', [coParamA, coParamB]);
-            const b = h.addTypeDef('typeB', [coParamA]);
-            h.addTypeDef('typeC');
-            h.addTypeDef('typeD');
-            b.addParent(new ExplicitInstantiation(
-                'typeA',
-                [
-                  new ExplicitInstantiation('typeC'),
-                  new GenericInstantiation('coA'),
-                ]));
-            h.finalize();
-
-            const typer = new ConnectionTyper(h);
-            const parent = createBlock('parent', '', ['typeA[typeC, typeD]']);
-            const middle = createBlock('middle', 'typeA[a, b]', ['typeB[b]']);
-            const child = createBlock('child', 'typeB[t]', ['typeB[t]']);
-            parent.getInput('0').connection.connect(middle.outputConnection);
-            middle.getInput('0').connection.connect(child.outputConnection);
-
-            assertConnectionType(
-                typer,
-                child.getInput('0').connection,
-                [new ExplicitInstantiation(
-                    'typeB', [new ExplicitInstantiation('typeD')])],
-                'Expected parameters to be properly reorganized for subtypes, and to travel through blocks');
-          });
-
-      test('typing a parameterized input without associated output', function() {
-        const h = new TypeHierarchy();
-        const coParam = new ParameterDefinition('co', Variance.CO);
-        h.addTypeDef('typeA', [coParam]);
-        h.addTypeDef('typeB');
-        h.finalize();
-
-        const typer = new ConnectionTyper(h);
-        const parent = createBlock('parent', '', ['typeA[typeB]']);
-        const child = createBlock('child', 'typeA[b]', ['typeA[t]']);
-        parent.getInput('0').connection.connect(child.outputConnection);
-
-        assertConnectionType(
-            typer,
-            child.getInput('0').connection,
-            [new ExplicitInstantiation('typeA', [new GenericInstantiation('')])],
-            'Expected unbound generics to be unnamed');
-      });
-
-      test('typing a paramterized input with the generic nested', function() {
-        const h = new TypeHierarchy();
-        const coParam = new ParameterDefinition('co', Variance.CO);
-        h.addTypeDef('typeA', [coParam]);
-        h.addTypeDef('typeB');
-        h.finalize();
-
-        const typer = new ConnectionTyper(h);
-        const parent = createBlock('parent', '', ['typeA[typeA[typeB]]']);
-        const child = createBlock('child', 'typeA[typeA[t]]', ['typeA[typeA[t]]']);
-        parent.getInput('0').connection.connect(child.outputConnection);
-
-        assertConnectionType(
-            typer,
-            child.getInput('0').connection,
-            [new ExplicitInstantiation(
-                'typeA', [new ExplicitInstantiation(
-                    'typeA', [new ExplicitInstantiation('typeB')])])],
-            'Expected the generic param to be properly bound, even though it is nested');
-      });
-
-      test('typing a parameterized output with parameterized input', function() {
-        const h = new TypeHierarchy();
-        const coParam = new ParameterDefinition('co', Variance.CO);
-        h.addTypeDef('typeA', [coParam]);
-        h.addTypeDef('typeB');
-        h.finalize();
-
-        const typer = new ConnectionTyper(h);
-        const parent = createBlock('parent', 'typeA[t]', ['typeA[t]']);
-        const child = createBlock('child', 'typeA[typeB]');
-        parent.getInput('0').connection.connect(child.outputConnection);
-
-        assertConnectionType(
-            typer,
-            parent.outputConnection,
-            [new ExplicitInstantiation(
-                'typeA', [new ExplicitInstantiation('typeB')])],
-            'Expected a parameterized output to be bound to the type attached to the input');
-      });
-
-      test('typing a parameterized output with parameterized input attached to sub', function() {
-        const h = new TypeHierarchy();
-        const coParamA = new ParameterDefinition('coA', Variance.CO);
-        const coParamB = new ParameterDefinition('coB', Variance.CO);
-        h.addTypeDef('typeA', [coParamA, coParamB]);
-        const b = h.addTypeDef('typeB', [coParamA]);
-        h.addTypeDef('typeC');
-        h.addTypeDef('typeD');
-        b.addParent(new ExplicitInstantiation(
-            'typeA',
-            [
-              new ExplicitInstantiation('typeC'),
-              new GenericInstantiation('coA'),
-            ]));
-        h.finalize();
+        test('typing a parameterized output with parameterized input attached to sub',
+            function() {
+              const h = new TypeHierarchy();
+              const coParamA = new ParameterDefinition('coA', Variance.CO);
+              const coParamB = new ParameterDefinition('coB', Variance.CO);
+              h.addTypeDef('typeA', [coParamA, coParamB]);
+              const b = h.addTypeDef('typeB', [coParamA]);
+              h.addTypeDef('typeC');
+              h.addTypeDef('typeD');
+              b.addParent(new ExplicitInstantiation(
+                  'typeA',
+                  [
+                    new ExplicitInstantiation('typeC'),
+                    new GenericInstantiation('coA'),
+                  ]));
+              h.finalize();
 
 
-        const typer = new ConnectionTyper(h);
-        const parent = createBlock('parent', 'typeA[a, b]', ['typeA[a, b]']);
-        const child = createBlock('child', 'typeB[typeD]');
-        parent.getInput('0').connection.connect(child.outputConnection);
+              const typer = new ConnectionTyper(h);
+              const parent = createBlock('parent', 'typeA[a, b]', ['typeA[a, b]']);
+              const child = createBlock('child', 'typeB[typeD]');
+              parent.getInput('0').connection.connect(child.outputConnection);
 
-        assertConnectionType(
-            typer,
-            parent.outputConnection,
-            [new ExplicitInstantiation(
-                'typeA',
-                [
-                  new ExplicitInstantiation('typeC'),
-                  new ExplicitInstantiation('typeD'),
-                ])],
-            'Expected parameters to be properly reorganized');
-      });
-
-      test('typing a parameterized output with multiple parameterized inputs',
-          function() {
-            const h = new TypeHierarchy();
-            const coParam = new ParameterDefinition('co', Variance.CO);
-            h.addTypeDef('typeA', [coParam]);
-            const b = h.addTypeDef('typeB');
-            const c = h.addTypeDef('typeC');
-            const d = h.addTypeDef('typeD');
-            c.addParent(b.createInstance());
-            d.addParent(b.createInstance());
-            h.finalize();
-
-            const typer = new ConnectionTyper(h);
-            const parent = createBlock(
-                'parent', 'typeA[t]', ['typeA[t]', 'typeA[t]']);
-            const childC = createBlock('child', 'typeA[typeC]');
-            const childD = createBlock('child', 'typeA[typeD]');
-            parent.getInput('0').connection.connect(childC.outputConnection);
-            parent.getInput('1').connection.connect(childD.outputConnection);
-
-            assertConnectionType(
-                typer,
-                parent.outputConnection,
-                [new ExplicitInstantiation(
-                    'typeA', [new ExplicitInstantiation('typeB')])],
-                'Expected params to inputs to be properly unified');
-          });
-
-      test('typing a parameterized output with generic input', function() {
-        const h = new TypeHierarchy();
-        const coParam = new ParameterDefinition('co', Variance.CO);
-        h.addTypeDef('typeA', [coParam]);
-        h.addTypeDef('typeB');
-        h.finalize();
-
-        const typer = new ConnectionTyper(h);
-        const parent = createBlock('parent', 'typeA[t]', ['t']);
-        const child = createBlock('child', 'typeB');
-        parent.getInput('0').connection.connect(child.outputConnection);
-
-        assertConnectionType(
-            typer,
-            parent.outputConnection,
-            [new ExplicitInstantiation(
-                'typeA', [new ExplicitInstantiation('typeB')])],
-            'Expected generics to be properly slotted into params');
-      });
-
-      test('typing a parameterized output with multiple generic inputs',
-          function() {
-            const h = new TypeHierarchy();
-            const coParam = new ParameterDefinition('co', Variance.CO);
-            h.addTypeDef('typeA', [coParam]);
-            const b = h.addTypeDef('typeB');
-            const c = h.addTypeDef('typeC');
-            const d = h.addTypeDef('typeD');
-            c.addParent(b.createInstance());
-            d.addParent(b.createInstance());
-            h.finalize();
-
-            const typer = new ConnectionTyper(h);
-            const parent = createBlock('parent', 'typeA[t]', ['t', 't']);
-            const childC = createBlock('child', 'typeC');
-            const childD = createBlock('child', 'typeD');
-            parent.getInput('0').connection.connect(childC.outputConnection);
-            parent.getInput('1').connection.connect(childD.outputConnection);
-
-            assertConnectionType(
-                typer,
-                parent.outputConnection,
-                [new ExplicitInstantiation(
-                    'typeA', [new ExplicitInstantiation('typeB')])],
-                'Expected generics to be properly unified');
-          });
-
-      test('typing a parameterized output with parameterized and generic inputs',
-          function() {
-            const h = new TypeHierarchy();
-            const coParam = new ParameterDefinition('co', Variance.CO);
-            h.addTypeDef('typeA', [coParam]);
-            const b = h.addTypeDef('typeB');
-            const c = h.addTypeDef('typeC');
-            const d = h.addTypeDef('typeD');
-            c.addParent(b.createInstance());
-            d.addParent(b.createInstance());
-            h.finalize();
-
-            const typer = new ConnectionTyper(h);
-            const parent = createBlock('parent', 'typeA[t]', ['t', 'typeA[t]']);
-            const childC = createBlock('child', 'typeC');
-            const childD = createBlock('child', 'typeA[typeD]');
-            parent.getInput('0').connection.connect(childC.outputConnection);
-            parent.getInput('1').connection.connect(childD.outputConnection);
-
-            assertConnectionType(
-                typer,
-                parent.outputConnection,
-                [new ExplicitInstantiation(
-                    'typeA', [new ExplicitInstantiation('typeB')])],
-                'Expected generics and params to be properly unified');
-          });
-
-      test('typing a parameterized output through a parameterized child',
-          function() {
-            const h = new TypeHierarchy();
-            const coParamA = new ParameterDefinition('coA', Variance.CO);
-            const coParamB = new ParameterDefinition('coB', Variance.CO);
-            h.addTypeDef('typeA', [coParamA, coParamB]);
-            const b = h.addTypeDef('typeB', [coParamA]);
-            h.addTypeDef('typeC');
-            h.addTypeDef('typeD');
-            b.addParent(new ExplicitInstantiation(
-                'typeA',
-                [
-                  new ExplicitInstantiation('typeC'),
-                  new GenericInstantiation('coA'),
-                ]));
-            h.finalize();
-
-            const typer = new ConnectionTyper(h);
-            const parent = createBlock('parent', 'typeA[a, b]', ['typeA[a, b]']);
-            const middle = createBlock('middle', 'typeA[a, b]', ['typeA[a, b]']);
-            const child = createBlock('child', 'typeB[typeD]');
-            parent.getInput('0').connection.connect(middle.outputConnection);
-            middle.getInput('0').connection.connect(child.outputConnection);
-
-            assertConnectionType(
-                typer,
-                parent.outputConnection,
-                [new ExplicitInstantiation(
-                    'typeA',
-                    [
-                      new ExplicitInstantiation('typeC'),
-                      new ExplicitInstantiation('typeD'),
-                    ])],
-                'Expected Expected parameters to be properly reorganized for subtypes, and to travel through blocks');
-          });
-
-      test('typing a paramterized output with multiple params that unify to multiple things',
-          function() {
-            const h = new TypeHierarchy();
-            const coParamA = new ParameterDefinition('coA', Variance.CO);
-            const coParamB = new ParameterDefinition('coB', Variance.CO);
-            h.addTypeDef('typeA', [coParamA, coParamB]);
-            h.addTypeDef('typeX', [coParamA]);
-            const b = h.addTypeDef('typeB');
-            const c = h.addTypeDef('typeC');
-            const d = h.addTypeDef('typeD');
-            const e = h.addTypeDef('typeE');
-            const f = h.addTypeDef('typeF');
-            const g = h.addTypeDef('typeG');
-            const i = h.addTypeDef('typeI');
-            const j = h.addTypeDef('typeJ');
-            d.addParent(b.createInstance());
-            d.addParent(c.createInstance());
-            e.addParent(b.createInstance());
-            e.addParent(c.createInstance());
-            i.addParent(f.createInstance());
-            i.addParent(g.createInstance());
-            j.addParent(f.createInstance());
-            j.addParent(g.createInstance());
-            h.finalize();
-
-            const typer = new ConnectionTyper(h);
-            const parent = createBlock(
-                'parent',
-                'typeA[a, b]',
-                ['typeX[a]', 'typeX[a]', 'typeX[b]', 'typeX[b]']);
-            const childD = createBlock('child', 'typeX[typeD]');
-            const childE = createBlock('child', 'typeX[typeE]');
-            const childI = createBlock('child', 'typeX[typeI]');
-            const childJ = createBlock('child', 'typeX[typeJ]');
-            parent.getInput('0').connection.connect(childD.outputConnection);
-            parent.getInput('1').connection.connect(childE.outputConnection);
-            parent.getInput('2').connection.connect(childI.outputConnection);
-            parent.getInput('3').connection.connect(childJ.outputConnection);
-
-            assertConnectionType(
-                typer,
-                parent.outputConnection,
-                [
-                  new ExplicitInstantiation(
-                      'typeA',
-                      [
-                        new ExplicitInstantiation('typeB'),
-                        new ExplicitInstantiation('typeF'),
-                      ]),
-                  new ExplicitInstantiation(
-                      'typeA',
-                      [
-                        new ExplicitInstantiation('typeB'),
-                        new ExplicitInstantiation('typeG'),
-                      ]),
-                  new ExplicitInstantiation(
+              assertConnectionType(
+                  typer,
+                  parent.outputConnection,
+                  [new ExplicitInstantiation(
                       'typeA',
                       [
                         new ExplicitInstantiation('typeC'),
-                        new ExplicitInstantiation('typeF'),
-                      ]),
-                  new ExplicitInstantiation(
+                        new ExplicitInstantiation('typeD'),
+                      ])],
+                  'Expected parameters to be properly reorganized');
+            });
+
+        test('typing a parameterized output with multiple parameterized inputs',
+            function() {
+              const h = new TypeHierarchy();
+              const coParam = new ParameterDefinition('co', Variance.CO);
+              h.addTypeDef('typeA', [coParam]);
+              const b = h.addTypeDef('typeB');
+              const c = h.addTypeDef('typeC');
+              const d = h.addTypeDef('typeD');
+              c.addParent(b.createInstance());
+              d.addParent(b.createInstance());
+              h.finalize();
+
+              const typer = new ConnectionTyper(h);
+              const parent = createBlock(
+                  'parent', 'typeA[t]', ['typeA[t]', 'typeA[t]']);
+              const childC = createBlock('child', 'typeA[typeC]');
+              const childD = createBlock('child', 'typeA[typeD]');
+              parent.getInput('0').connection.connect(childC.outputConnection);
+              parent.getInput('1').connection.connect(childD.outputConnection);
+
+              assertConnectionType(
+                  typer,
+                  parent.outputConnection,
+                  [new ExplicitInstantiation(
+                      'typeA', [new ExplicitInstantiation('typeB')])],
+                  'Expected params to inputs to be properly unified');
+            });
+
+        test('typing a parameterized output with generic input', function() {
+          const h = new TypeHierarchy();
+          const coParam = new ParameterDefinition('co', Variance.CO);
+          h.addTypeDef('typeA', [coParam]);
+          h.addTypeDef('typeB');
+          h.finalize();
+
+          const typer = new ConnectionTyper(h);
+          const parent = createBlock('parent', 'typeA[t]', ['t']);
+          const child = createBlock('child', 'typeB');
+          parent.getInput('0').connection.connect(child.outputConnection);
+
+          assertConnectionType(
+              typer,
+              parent.outputConnection,
+              [new ExplicitInstantiation(
+                  'typeA', [new ExplicitInstantiation('typeB')])],
+              'Expected generics to be properly slotted into params');
+        });
+
+        test('typing a parameterized output with multiple generic inputs',
+            function() {
+              const h = new TypeHierarchy();
+              const coParam = new ParameterDefinition('co', Variance.CO);
+              h.addTypeDef('typeA', [coParam]);
+              const b = h.addTypeDef('typeB');
+              const c = h.addTypeDef('typeC');
+              const d = h.addTypeDef('typeD');
+              c.addParent(b.createInstance());
+              d.addParent(b.createInstance());
+              h.finalize();
+
+              const typer = new ConnectionTyper(h);
+              const parent = createBlock('parent', 'typeA[t]', ['t', 't']);
+              const childC = createBlock('child', 'typeC');
+              const childD = createBlock('child', 'typeD');
+              parent.getInput('0').connection.connect(childC.outputConnection);
+              parent.getInput('1').connection.connect(childD.outputConnection);
+
+              assertConnectionType(
+                  typer,
+                  parent.outputConnection,
+                  [new ExplicitInstantiation(
+                      'typeA', [new ExplicitInstantiation('typeB')])],
+                  'Expected generics to be properly unified');
+            });
+
+        test('typing a parameterized output with parameterized and generic inputs',
+            function() {
+              const h = new TypeHierarchy();
+              const coParam = new ParameterDefinition('co', Variance.CO);
+              h.addTypeDef('typeA', [coParam]);
+              const b = h.addTypeDef('typeB');
+              const c = h.addTypeDef('typeC');
+              const d = h.addTypeDef('typeD');
+              c.addParent(b.createInstance());
+              d.addParent(b.createInstance());
+              h.finalize();
+
+              const typer = new ConnectionTyper(h);
+              const parent = createBlock('parent', 'typeA[t]', ['t', 'typeA[t]']);
+              const childC = createBlock('child', 'typeC');
+              const childD = createBlock('child', 'typeA[typeD]');
+              parent.getInput('0').connection.connect(childC.outputConnection);
+              parent.getInput('1').connection.connect(childD.outputConnection);
+
+              assertConnectionType(
+                  typer,
+                  parent.outputConnection,
+                  [new ExplicitInstantiation(
+                      'typeA', [new ExplicitInstantiation('typeB')])],
+                  'Expected generics and params to be properly unified');
+            });
+
+        test('typing a parameterized output through a parameterized child',
+            function() {
+              const h = new TypeHierarchy();
+              const coParamA = new ParameterDefinition('coA', Variance.CO);
+              const coParamB = new ParameterDefinition('coB', Variance.CO);
+              h.addTypeDef('typeA', [coParamA, coParamB]);
+              const b = h.addTypeDef('typeB', [coParamA]);
+              h.addTypeDef('typeC');
+              h.addTypeDef('typeD');
+              b.addParent(new ExplicitInstantiation(
+                  'typeA',
+                  [
+                    new ExplicitInstantiation('typeC'),
+                    new GenericInstantiation('coA'),
+                  ]));
+              h.finalize();
+
+              const typer = new ConnectionTyper(h);
+              const parent = createBlock('parent', 'typeA[a, b]', ['typeA[a, b]']);
+              const middle = createBlock('middle', 'typeA[a, b]', ['typeA[a, b]']);
+              const child = createBlock('child', 'typeB[typeD]');
+              parent.getInput('0').connection.connect(middle.outputConnection);
+              middle.getInput('0').connection.connect(child.outputConnection);
+
+              assertConnectionType(
+                  typer,
+                  parent.outputConnection,
+                  [new ExplicitInstantiation(
                       'typeA',
                       [
                         new ExplicitInstantiation('typeC'),
-                        new ExplicitInstantiation('typeG'),
-                      ]),
-                ],
-                'Expected params unifying to multiple types to result in multiple types');
-          });
+                        new ExplicitInstantiation('typeD'),
+                      ])],
+                  'Expected Expected parameters to be properly reorganized for subtypes, and to travel through blocks');
+            });
 
-      test('typing a paramterized output with multiple params that unify to multiple things through children',
-          function() {
-            const h = new TypeHierarchy();
-            const coParamA = new ParameterDefinition('coA', Variance.CO);
-            const coParamB = new ParameterDefinition('coB', Variance.CO);
-            h.addTypeDef('typeA', [coParamA, coParamB]);
-            h.addTypeDef('typeX', [coParamA]);
-            const b = h.addTypeDef('typeB');
-            const c = h.addTypeDef('typeC');
-            const d = h.addTypeDef('typeD');
-            const e = h.addTypeDef('typeE');
-            const f = h.addTypeDef('typeF');
-            const g = h.addTypeDef('typeG');
-            const i = h.addTypeDef('typeI');
-            const j = h.addTypeDef('typeJ');
-            d.addParent(b.createInstance());
-            d.addParent(c.createInstance());
-            e.addParent(b.createInstance());
-            e.addParent(c.createInstance());
-            i.addParent(f.createInstance());
-            i.addParent(g.createInstance());
-            j.addParent(f.createInstance());
-            j.addParent(g.createInstance());
-            h.finalize();
+        test('typing a paramterized output with multiple params that unify to multiple things',
+            function() {
+              const h = new TypeHierarchy();
+              const coParamA = new ParameterDefinition('coA', Variance.CO);
+              const coParamB = new ParameterDefinition('coB', Variance.CO);
+              h.addTypeDef('typeA', [coParamA, coParamB]);
+              h.addTypeDef('typeX', [coParamA]);
+              const b = h.addTypeDef('typeB');
+              const c = h.addTypeDef('typeC');
+              const d = h.addTypeDef('typeD');
+              const e = h.addTypeDef('typeE');
+              const f = h.addTypeDef('typeF');
+              const g = h.addTypeDef('typeG');
+              const i = h.addTypeDef('typeI');
+              const j = h.addTypeDef('typeJ');
+              d.addParent(b.createInstance());
+              d.addParent(c.createInstance());
+              e.addParent(b.createInstance());
+              e.addParent(c.createInstance());
+              i.addParent(f.createInstance());
+              i.addParent(g.createInstance());
+              j.addParent(f.createInstance());
+              j.addParent(g.createInstance());
+              h.finalize();
 
-            const typer = new ConnectionTyper(h);
-            const parent = createBlock(
-                'parent', 'typeA[a, b]', ['typeX[a]', 'typeX[b]']);
-            const middle1 = createBlock(
-                'middle1', 'typeX[t]', ['typeX[t]', 'typeX[t]']);
-            const middle2 = createBlock(
-                'middle2', 'typeX[t]', ['typeX[t]', 'typeX[t]']);
-            const childD = createBlock('child', 'typeX[typeD]');
-            const childE = createBlock('child', 'typeX[typeE]');
-            const childI = createBlock('child', 'typeX[typeI]');
-            const childJ = createBlock('child', 'typeX[typeJ]');
-            parent.getInput('0').connection.connect(middle1.outputConnection);
-            parent.getInput('1').connection.connect(middle2.outputConnection);
-            middle1.getInput('0').connection.connect(childD.outputConnection);
-            middle1.getInput('1').connection.connect(childE.outputConnection);
-            middle2.getInput('0').connection.connect(childI.outputConnection);
-            middle2.getInput('1').connection.connect(childJ.outputConnection);
+              const typer = new ConnectionTyper(h);
+              const parent = createBlock(
+                  'parent',
+                  'typeA[a, b]',
+                  ['typeX[a]', 'typeX[a]', 'typeX[b]', 'typeX[b]']);
+              const childD = createBlock('child', 'typeX[typeD]');
+              const childE = createBlock('child', 'typeX[typeE]');
+              const childI = createBlock('child', 'typeX[typeI]');
+              const childJ = createBlock('child', 'typeX[typeJ]');
+              parent.getInput('0').connection.connect(childD.outputConnection);
+              parent.getInput('1').connection.connect(childE.outputConnection);
+              parent.getInput('2').connection.connect(childI.outputConnection);
+              parent.getInput('3').connection.connect(childJ.outputConnection);
 
-            assertConnectionType(
-                typer,
-                parent.outputConnection,
-                [
-                  new ExplicitInstantiation(
+              assertConnectionType(
+                  typer,
+                  parent.outputConnection,
+                  [
+                    new ExplicitInstantiation(
+                        'typeA',
+                        [
+                          new ExplicitInstantiation('typeB'),
+                          new ExplicitInstantiation('typeF'),
+                        ]),
+                    new ExplicitInstantiation(
+                        'typeA',
+                        [
+                          new ExplicitInstantiation('typeB'),
+                          new ExplicitInstantiation('typeG'),
+                        ]),
+                    new ExplicitInstantiation(
+                        'typeA',
+                        [
+                          new ExplicitInstantiation('typeC'),
+                          new ExplicitInstantiation('typeF'),
+                        ]),
+                    new ExplicitInstantiation(
+                        'typeA',
+                        [
+                          new ExplicitInstantiation('typeC'),
+                          new ExplicitInstantiation('typeG'),
+                        ]),
+                  ],
+                  'Expected params unifying to multiple types to result in multiple types');
+            });
+
+        test('typing a paramterized output with multiple params that unify to multiple things through children',
+            function() {
+              const h = new TypeHierarchy();
+              const coParamA = new ParameterDefinition('coA', Variance.CO);
+              const coParamB = new ParameterDefinition('coB', Variance.CO);
+              h.addTypeDef('typeA', [coParamA, coParamB]);
+              h.addTypeDef('typeX', [coParamA]);
+              const b = h.addTypeDef('typeB');
+              const c = h.addTypeDef('typeC');
+              const d = h.addTypeDef('typeD');
+              const e = h.addTypeDef('typeE');
+              const f = h.addTypeDef('typeF');
+              const g = h.addTypeDef('typeG');
+              const i = h.addTypeDef('typeI');
+              const j = h.addTypeDef('typeJ');
+              d.addParent(b.createInstance());
+              d.addParent(c.createInstance());
+              e.addParent(b.createInstance());
+              e.addParent(c.createInstance());
+              i.addParent(f.createInstance());
+              i.addParent(g.createInstance());
+              j.addParent(f.createInstance());
+              j.addParent(g.createInstance());
+              h.finalize();
+
+              const typer = new ConnectionTyper(h);
+              const parent = createBlock(
+                  'parent', 'typeA[a, b]', ['typeX[a]', 'typeX[b]']);
+              const middle1 = createBlock(
+                  'middle1', 'typeX[t]', ['typeX[t]', 'typeX[t]']);
+              const middle2 = createBlock(
+                  'middle2', 'typeX[t]', ['typeX[t]', 'typeX[t]']);
+              const childD = createBlock('child', 'typeX[typeD]');
+              const childE = createBlock('child', 'typeX[typeE]');
+              const childI = createBlock('child', 'typeX[typeI]');
+              const childJ = createBlock('child', 'typeX[typeJ]');
+              parent.getInput('0').connection.connect(middle1.outputConnection);
+              parent.getInput('1').connection.connect(middle2.outputConnection);
+              middle1.getInput('0').connection.connect(childD.outputConnection);
+              middle1.getInput('1').connection.connect(childE.outputConnection);
+              middle2.getInput('0').connection.connect(childI.outputConnection);
+              middle2.getInput('1').connection.connect(childJ.outputConnection);
+
+              assertConnectionType(
+                  typer,
+                  parent.outputConnection,
+                  [
+                    new ExplicitInstantiation(
+                        'typeA',
+                        [
+                          new ExplicitInstantiation('typeB'),
+                          new ExplicitInstantiation('typeF'),
+                        ]),
+                    new ExplicitInstantiation(
+                        'typeA',
+                        [
+                          new ExplicitInstantiation('typeB'),
+                          new ExplicitInstantiation('typeG'),
+                        ]),
+                    new ExplicitInstantiation(
+                        'typeA',
+                        [
+                          new ExplicitInstantiation('typeC'),
+                          new ExplicitInstantiation('typeF'),
+                        ]),
+                    new ExplicitInstantiation(
+                        'typeA',
+                        [
+                          new ExplicitInstantiation('typeC'),
+                          new ExplicitInstantiation('typeG'),
+                        ]),
+                  ],
+                  'Expected params unifying to multiple types to result in multiple types');
+            });
+
+        test('typing a generic output with parameterized input', function() {
+          const h = new TypeHierarchy();
+          const coParam = new ParameterDefinition('co', Variance.CO);
+          h.addTypeDef('typeA', [coParam]);
+          h.addTypeDef('typeB');
+          h.finalize();
+
+          const typer = new ConnectionTyper(h);
+          const parent = createBlock('parent', 't', ['typeA[t]']);
+          const child = createBlock('child', 'typeA[typeB]');
+          parent.getInput('0').connection.connect(child.outputConnection);
+
+          assertConnectionType(
+              typer,
+              parent.outputConnection,
+              [new ExplicitInstantiation('typeB')],
+              'Expected generics to be properly bound to params');
+        });
+
+        test('typing a generic output with multiple parameterized inputs',
+            function() {
+              const h = new TypeHierarchy();
+              const coParam = new ParameterDefinition('co', Variance.CO);
+              h.addTypeDef('typeA', [coParam]);
+              const b = h.addTypeDef('typeB');
+              const c = h.addTypeDef('typeC');
+              const d = h.addTypeDef('typeD');
+              c.addParent(b.createInstance());
+              d.addParent(b.createInstance());
+              h.finalize();
+
+              const typer = new ConnectionTyper(h);
+              const parent = createBlock('parent', 't', ['typeA[t]', 'typeA[t]']);
+              const childC = createBlock('child', 'typeA[typeC]');
+              const childD = createBlock('child', 'typeA[typeD]');
+              parent.getInput('0').connection.connect(childC.outputConnection);
+              parent.getInput('1').connection.connect(childD.outputConnection);
+
+              assertConnectionType(
+                  typer,
+                  parent.outputConnection,
+                  [new ExplicitInstantiation('typeB')],
+                  'Expected params to be properly unified');
+            });
+
+        test('typing a generic output with parameterized and generic inputs',
+            function() {
+              const h = new TypeHierarchy();
+              const coParam = new ParameterDefinition('co', Variance.CO);
+              h.addTypeDef('typeA', [coParam]);
+              const b = h.addTypeDef('typeB');
+              const c = h.addTypeDef('typeC');
+              const d = h.addTypeDef('typeD');
+              c.addParent(b.createInstance());
+              d.addParent(b.createInstance());
+              h.finalize();
+
+              const typer = new ConnectionTyper(h);
+              const parent = createBlock('parent', 't', ['typeA[t]', 't']);
+              const childC = createBlock('child', 'typeA[typeC]');
+              const childD = createBlock('child', 'typeD');
+              parent.getInput('0').connection.connect(childC.outputConnection);
+              parent.getInput('1').connection.connect(childD.outputConnection);
+
+              assertConnectionType(
+                  typer,
+                  parent.outputConnection,
+                  [new ExplicitInstantiation('typeB')],
+                  'Expected params and generics to be properly unified');
+            });
+
+        test('typing a parameterized output without associated input', function() {
+          const h = new TypeHierarchy();
+          const coParam = new ParameterDefinition('co', Variance.CO);
+          h.addTypeDef('typeA', [coParam]);
+          h.addTypeDef('typeB');
+          h.finalize();
+
+          const typer = new ConnectionTyper(h);
+          const parent = createBlock('parent', 'typeA[t]', ['typeA[b]']);
+          const child = createBlock('child', 'typeA[typeB]');
+          parent.getInput('0').connection.connect(child.outputConnection);
+
+          assertConnectionType(
+              typer,
+              parent.outputConnection,
+              [new ExplicitInstantiation('typeA', [new GenericInstantiation('')])],
+              'Expected unbound generics to be unnamed');
+        });
+
+        test('typing a parameterized output without one generic associated with an input, and the other not',
+            function() {
+              const h = new TypeHierarchy();
+              const coParamA = new ParameterDefinition('coA', Variance.CO);
+              const coParamB = new ParameterDefinition('coB', Variance.CO);
+              h.addTypeDef('typeA', [coParamA, coParamB]);
+              const b = h.addTypeDef('typeB', [coParamA]);
+              h.addTypeDef('typeC');
+              h.addTypeDef('typeD');
+              b.addParent(new ExplicitInstantiation(
+                  'typeA',
+                  [
+                    new ExplicitInstantiation('typeC'),
+                    new GenericInstantiation('coA'),
+                  ]));
+              h.finalize();
+
+
+              const typer = new ConnectionTyper(h);
+              const parent = createBlock('parent', 'typeA[a, b]', ['typeB[b]']);
+              const child = createBlock('child', 'typeB[typeD]');
+              parent.getInput('0').connection.connect(child.outputConnection);
+
+              assertConnectionType(
+                  typer,
+                  parent.outputConnection,
+                  [new ExplicitInstantiation(
                       'typeA',
                       [
-                        new ExplicitInstantiation('typeB'),
-                        new ExplicitInstantiation('typeF'),
-                      ]),
-                  new ExplicitInstantiation(
-                      'typeA',
-                      [
-                        new ExplicitInstantiation('typeB'),
-                        new ExplicitInstantiation('typeG'),
-                      ]),
-                  new ExplicitInstantiation(
-                      'typeA',
-                      [
-                        new ExplicitInstantiation('typeC'),
-                        new ExplicitInstantiation('typeF'),
-                      ]),
-                  new ExplicitInstantiation(
-                      'typeA',
-                      [
-                        new ExplicitInstantiation('typeC'),
-                        new ExplicitInstantiation('typeG'),
-                      ]),
-                ],
-                'Expected params unifying to multiple types to result in multiple types');
-          });
+                        new GenericInstantiation(''),
+                        new ExplicitInstantiation('typeD'),
+                      ])],
+                  'Expected unbound generics to be unnamed');
+            });
 
-      test('typing a generic output with parameterized input', function() {
-        const h = new TypeHierarchy();
-        const coParam = new ParameterDefinition('co', Variance.CO);
-        h.addTypeDef('typeA', [coParam]);
-        h.addTypeDef('typeB');
-        h.finalize();
+        test('typing a paramterized output with the generic nested', function() {
+          const h = new TypeHierarchy();
+          const coParam = new ParameterDefinition('co', Variance.CO);
+          h.addTypeDef('typeA', [coParam]);
+          h.addTypeDef('typeB');
+          h.finalize();
 
-        const typer = new ConnectionTyper(h);
-        const parent = createBlock('parent', 't', ['typeA[t]']);
-        const child = createBlock('child', 'typeA[typeB]');
-        parent.getInput('0').connection.connect(child.outputConnection);
+          const typer = new ConnectionTyper(h);
+          const parent = createBlock(
+              'parent', 'typeA[typeA[t]]', ['typeA[typeA[t]]']);
+          const child = createBlock('child', 'typeA[typeA[typeB]]');
+          parent.getInput('0').connection.connect(child.outputConnection);
 
-        assertConnectionType(
-            typer,
-            parent.outputConnection,
-            [new ExplicitInstantiation('typeB')],
-            'Expected generics to be properly bound to params');
-      });
-
-      test('typing a generic output with multiple parameterized inputs',
-          function() {
-            const h = new TypeHierarchy();
-            const coParam = new ParameterDefinition('co', Variance.CO);
-            h.addTypeDef('typeA', [coParam]);
-            const b = h.addTypeDef('typeB');
-            const c = h.addTypeDef('typeC');
-            const d = h.addTypeDef('typeD');
-            c.addParent(b.createInstance());
-            d.addParent(b.createInstance());
-            h.finalize();
-
-            const typer = new ConnectionTyper(h);
-            const parent = createBlock('parent', 't', ['typeA[t]', 'typeA[t]']);
-            const childC = createBlock('child', 'typeA[typeC]');
-            const childD = createBlock('child', 'typeA[typeD]');
-            parent.getInput('0').connection.connect(childC.outputConnection);
-            parent.getInput('1').connection.connect(childD.outputConnection);
-
-            assertConnectionType(
-                typer,
-                parent.outputConnection,
-                [new ExplicitInstantiation('typeB')],
-                'Expected params to be properly unified');
-          });
-
-      test('typing a generic output with parameterized and generic inputs',
-          function() {
-            const h = new TypeHierarchy();
-            const coParam = new ParameterDefinition('co', Variance.CO);
-            h.addTypeDef('typeA', [coParam]);
-            const b = h.addTypeDef('typeB');
-            const c = h.addTypeDef('typeC');
-            const d = h.addTypeDef('typeD');
-            c.addParent(b.createInstance());
-            d.addParent(b.createInstance());
-            h.finalize();
-
-            const typer = new ConnectionTyper(h);
-            const parent = createBlock('parent', 't', ['typeA[t]', 't']);
-            const childC = createBlock('child', 'typeA[typeC]');
-            const childD = createBlock('child', 'typeD');
-            parent.getInput('0').connection.connect(childC.outputConnection);
-            parent.getInput('1').connection.connect(childD.outputConnection);
-
-            assertConnectionType(
-                typer,
-                parent.outputConnection,
-                [new ExplicitInstantiation('typeB')],
-                'Expected params and generics to be properly unified');
-          });
-
-
-      test('typing a parameterized output without associated input', function() {
-        const h = new TypeHierarchy();
-        const coParam = new ParameterDefinition('co', Variance.CO);
-        h.addTypeDef('typeA', [coParam]);
-        h.addTypeDef('typeB');
-        h.finalize();
-
-        const typer = new ConnectionTyper(h);
-        const parent = createBlock('parent', 'typeA[t]', ['typeA[b]']);
-        const child = createBlock('child', 'typeA[typeB]');
-        parent.getInput('0').connection.connect(child.outputConnection);
-
-        assertConnectionType(
-            typer,
-            parent.outputConnection,
-            [new ExplicitInstantiation('typeA', [new GenericInstantiation('')])],
-            'Expected unbound generics to be unnamed');
-      });
-
-      test('typing a parameterized output without one generic associated with an input, and the other not',
-          function() {
-            const h = new TypeHierarchy();
-            const coParamA = new ParameterDefinition('coA', Variance.CO);
-            const coParamB = new ParameterDefinition('coB', Variance.CO);
-            h.addTypeDef('typeA', [coParamA, coParamB]);
-            const b = h.addTypeDef('typeB', [coParamA]);
-            h.addTypeDef('typeC');
-            h.addTypeDef('typeD');
-            b.addParent(new ExplicitInstantiation(
-                'typeA',
-                [
-                  new ExplicitInstantiation('typeC'),
-                  new GenericInstantiation('coA'),
-                ]));
-            h.finalize();
-
-
-            const typer = new ConnectionTyper(h);
-            const parent = createBlock('parent', 'typeA[a, b]', ['typeB[b]']);
-            const child = createBlock('child', 'typeB[typeD]');
-            parent.getInput('0').connection.connect(child.outputConnection);
-
-            assertConnectionType(
-                typer,
-                parent.outputConnection,
-                [new ExplicitInstantiation(
-                    'typeA',
-                    [
-                      new GenericInstantiation(''),
-                      new ExplicitInstantiation('typeD'),
-                    ])],
-                'Expected unbound generics to be unnamed');
-          });
-
-      test('typing a paramterized output with the generic nested', function() {
-        const h = new TypeHierarchy();
-        const coParam = new ParameterDefinition('co', Variance.CO);
-        h.addTypeDef('typeA', [coParam]);
-        h.addTypeDef('typeB');
-        h.finalize();
-
-        const typer = new ConnectionTyper(h);
-        const parent = createBlock(
-            'parent', 'typeA[typeA[t]]', ['typeA[typeA[t]]']);
-        const child = createBlock('child', 'typeA[typeA[typeB]]');
-        parent.getInput('0').connection.connect(child.outputConnection);
-
-        assertConnectionType(
-            typer,
-            parent.outputConnection,
-            [new ExplicitInstantiation(
-                'typeA', [new ExplicitInstantiation(
-                    'typeA', [new ExplicitInstantiation('typeB')])])],
-            'Expected the generic param to be properly bound, even though it is nested');
+          assertConnectionType(
+              typer,
+              parent.outputConnection,
+              [new ExplicitInstantiation(
+                  'typeA', [new ExplicitInstantiation(
+                      'typeA', [new ExplicitInstantiation('typeB')])])],
+              'Expected the generic param to be properly bound, even though it is nested');
+        });
       });
     });
   });


### PR DESCRIPTION
### :clap: Resolves

<!-- The github issue this PR is for. If this PR closes the issue please
     put the word "Closes" before the issue -->
     
N/A
     
### :star2: Description

<!-- A description of what your PR does -->
Adds the ability to bind covariant generic paramters to explicit types based on connections

### :bug: Testing

<!-- A list of steps you used for testing, or a list of unit tests you added. -->
Lots o'tests, covering all the behavior for covariant params, which are not duplicated within a given type.

### :thought_balloon: Other info

<!-- Links to other relevant issues, pull requests, or information -->
N/A